### PR TITLE
Fix parameter list typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class { 'puppetboard': }
 
 # Access Puppetboard through pboard.example.com
 class { 'puppetboard::apache::vhost':
-  vhost_name 'pboard.example.com',
+  vhost_name => 'pboard.example.com',
 }
 ```
 


### PR DESCRIPTION
The vhost_name parameter of puppetboard::apache::vhost was missing a => in the README.
