### PR TITLE
change base install directory to '$basedir'

### DIFF
--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -6,9 +6,10 @@ class puppetboard::apache::conf (
   $threads    = 5,
   $user       = $::puppetboard::params::user,
   $group      = $::puppetboard::params::group,
+  $basedir    = $::puppetboard::params::basedir,
 ) inherits ::puppetboard::params {
 
-  $docroot = "/home/${user}/puppetboard"
+  $docroot = "${basedir}/puppetboard"
 
   file { "${docroot}/wsgi.py":
     ensure  => present,

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -4,9 +4,10 @@ class puppetboard::apache::vhost (
   $threads     = 5,
   $user        = $::puppetboard::params::user,
   $group       = $::puppetboard::params::group,
+  $basedir     = $::puppetboard::params::basedir,
 ) inherits ::puppetboard::params {
 
-  $docroot = "/home/${user}/puppetboard"
+  $docroot = "${basedir}/puppetboard"
 
   $wsgi_script_aliases = {
     '/' => "${docroot}/wsgi.py",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,5 +13,6 @@ class puppetboard::params {
 
   $user  = 'puppetboard'
   $group = 'puppetboard'
+  $basedir = '/srv/puppetboard'
 
 }

--- a/templates/wsgi.py.erb
+++ b/templates/wsgi.py.erb
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-activate_this = '/home/<%= @user %>/virtenv-puppetboard/bin/activate_this.py'
+activate_this = '<%= @basedir %>/virtenv-puppetboard/bin/activate_this.py'
 execfile(activate_this, dict(__file__=activate_this))
 
 import os


### PR DESCRIPTION
Add parameter $basedir.
Relocate installation base directory to $basedir.
Make user resource a 'system' user to avoid UID conflicts when provissioning
users with LDAP.
