### PR TITLE
add class parameters to configure default_settings.py

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,4 +15,17 @@ class puppetboard::params {
   $group = 'puppetboard'
   $basedir = '/srv/puppetboard'
 
+  $puppetdb_host = 'localhost'
+  $puppetdb_port = 8080
+  $puppetdb_key = 'None'
+  $puppetdb_ssl = 'False'
+  $puppetdb_cert = 'None'
+  $puppetdb_timeout = 20
+  $dev_listen_host = '127.0.0.1'
+  $dev_listen_port = 5000
+  $unresponsive = 3
+  $enable_query = 'True'
+  $python_loglevel = 'info'
+  $experimental = 'False'
+
 }

--- a/templates/default_settings.py.erb
+++ b/templates/default_settings.py.erb
@@ -1,0 +1,12 @@
+PUPPETDB_HOST = '<%= @puppetdb_host %>'
+PUPPETDB_PORT = <%= @puppetdb_port %>
+PUPPETDB_SSL = <%= @puppetdb_ssl %>
+PUPPETDB_KEY = <%= @puppetdb_key %>
+PUPPETDB_CERT = <%= @puppetdb_cert %>
+PUPPETDB_TIMEOUT = <%= @puppetdb_timeout %>
+DEV_LISTEN_HOST = '<%= @dev_listen_host %>'
+DEV_LISTEN_PORT = <%= @dev_listen_port %>
+UNRESPONSIVE_HOURS = <%= @unresponsive %>
+ENABLE_QUERY = <%= @enable_query %>
+LOGLEVEL = '<%= @python_loglevel %>'
+PUPPETDB_EXPERIMENTAL = <%= @experimental %>


### PR DESCRIPTION
This commit adds class parameters to the puppetboard class to
automatically setup the puppetboard configuration file default_settings.py

The following parameters were added:

```
  $puppetdb_host = 'localhost'
  $puppetdb_port = 8080
  $puppetdb_key = 'None'
  $puppetdb_ssl = 'False'
  $puppetdb_cert = 'None'
  $puppetdb_timeout = 20
  $dev_listen_host = '127.0.0.1'
  $dev_listen_port = 5000
  $unresponsive = 3
  $enable_query = 'True'
  $python_loglevel = 'info'
```

The experimental parameter changed from true/false to a string
to support the Python bool True/False:

```
$experimental = 'False'
```
