### PR TITLE
Fix problem with pip install git requirement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,6 +109,7 @@ class puppetboard(
     systempkgs   => true,
     distribute   => false,
     owner        => $user,
+    cwd          => "${basedir}/puppetboard",
     require      => Vcsrepo["${basedir}/puppetboard"],
   }
 


### PR DESCRIPTION
Your module is really great, but when I have run it in my environment (Ubuntu 12.04.3, Python  2.7.3, Pip 1.4.1, Git 1.7.9.5) it failed to install requirements. Puppetboard has one git requirement and it fail with following message:

```
Command /usr/bin/git clone -q git://github.com/nedap/pypuppetdb.git /var/www/puppetboard/virtenv-puppetboard/build/pypuppetdb failed with error code 128 in None
```

I have default config for class

```
    class { 'puppetboard': 
        basedir => '/var/www/puppetboard',
        require => [Package['git'], Class['python']]
    }
```

So I have found that add correct 'cwd' to puppetboard repository fix my problem, but I'm not python dev so I'm not sure in this fix.
