### PR TITLE
Document parameters for all classes, and variables used by templates

### DIFF
--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -1,5 +1,38 @@
+# == Class: puppetboard::apache::conf
+#
+# Creates an entry in your apache configuration directory
+# to run PuppetBoard server-wide (i.e. not in a vhost).
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*wsgi_alias*]
+#   (string) WSGI script alias source
+#   Default: '/puppetboard'
+#
+# [*threads*]
+#   (int) Number of WSGI threads to use.
+#   Defaults to 5
+#
+# [*user*]
+#   (string) WSGI daemon process user, and daemon process name
+#   Defaults to 'puppetboard' ($::puppetboard::params::user)
+#
+# [*group*]
+#   (int) WSGI daemon process group owner, and daemon process group
+#   Defaults to 'puppetboard' ($::puppetboard::params::group)
+#
+# [*basedir*]
+#   (string) Base directory where to build puppetboard vcsrepo and python virtualenv.
+#   Defaults to '/srv/puppetboard' ($::puppetboard::params::basedir)
+#
+# === Notes:
 #
 # Make sure you have purge_configs set to false in your apache class!
+#
+# This runs the WSGI application with a WSGIProcessGroup of $user and
+# a WSGIApplicationGroup of %{GLOBAL}.
 #
 class puppetboard::apache::conf (
   $wsgi_alias = '/puppetboard',
@@ -11,6 +44,9 @@ class puppetboard::apache::conf (
 
   $docroot = "${basedir}/puppetboard"
 
+  # Template Uses:
+  # - $basedir
+  #
   file { "${docroot}/wsgi.py":
     ensure  => present,
     content => template('puppetboard/wsgi.py.erb'),
@@ -19,6 +55,13 @@ class puppetboard::apache::conf (
     require => User[$user],
   }
 
+  # Template Uses:
+  # - $user
+  # - $group
+  # - $threads
+  # - $wsgi_alias
+  # - $docroot
+  #
   file { "${::puppetboard::params::apache_confd}/puppetboard.conf":
     ensure  => present,
     owner   => 'root',

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -1,3 +1,36 @@
+# == Class: puppetboard::apache::vhost
+#
+# Sets up an apache::vhost to run PuppetBoard,
+# and writes an appropriate wsgi.py from template.
+#
+# === Parameters
+#
+# Document parameters here.
+#
+# [*vhost_name*]
+#   (string) The vhost ServerName.
+#   No default.
+#
+# [*port*]
+#   (int) Port for the vhost to listen on.
+#   Defaults to 5000.
+#
+# [*threads*]
+#   (int) Number of WSGI threads to use.
+#   Defaults to 5
+#
+# [*user*]
+#   (string) WSGI daemon process user, and daemon process name
+#   Defaults to 'puppetboard' ($::puppetboard::params::user)
+#
+# [*group*]
+#   (int) WSGI daemon process group owner, and daemon process group
+#   Defaults to 'puppetboard' ($::puppetboard::params::group)
+#
+# [*basedir*]
+#   (string) Base directory where to build puppetboard vcsrepo and python virtualenv.
+#   Defaults to '/srv/puppetboard' ($::puppetboard::params::basedir)
+#
 class puppetboard::apache::vhost (
   $vhost_name,
   $port        = 5000,
@@ -19,6 +52,9 @@ class puppetboard::apache::vhost (
     user    => $user,
   }
 
+  # Template Uses:
+  # - $basedir
+  #
   file { "${docroot}/wsgi.py":
     ensure  => present,
     content => template('puppetboard/wsgi.py.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,20 +10,64 @@
 # Document parameters here.
 #
 # [*user*]
-#   Puppetboard system user.
-#   Defaults to 'puppetboard'
+#   (string) Puppetboard system user.
+#   Defaults to 'puppetboard' ($::puppetboard::params::user)
 #
 # [*group*]
-#   Puppetboard system group.
-#   Defaults to 'puppetboard'
+#   (string) Puppetboard system group.
+#   Defaults to 'puppetboard' ($::puppetboard::params::group)
 #
 # [*basedir*]
-#   Base directory where to build puppetboard vcsrepo and python virtualenv.
-#   Defaults to '/srv/puppetboard'
+#   (string) Base directory where to build puppetboard vcsrepo and python virtualenv.
+#   Defaults to '/srv/puppetboard' ($::puppetboard::params::basedir)
+#
+# [*puppetdb_host*]
+#   (string) PuppetDB Host
+#   Defaults to 'localhost' ($::puppetboard::params::puppetdb_host)
+#
+# [*puppetdb_port*]
+#   (int) PuppetDB Port
+#   Defaults to 8080 ($::puppetboard::params::puppetdb_port)
+#
+# [*puppetdb_key*]
+#   (string, absolute path) path to PuppetMaster/CA signed client SSL key
+#   Defaults to 'None' ($::puppetboard::params::puppetdb_key)
+#
+# [*puppetdb_ssl*]
+#   (string) whether PuppetDB uses SSL or not,  'True' or 'False'.
+#   Defaults to 'False' ($::puppetboard::params::puppetdb_ssl)
+#
+# [*puppetdb_cert*]
+#   (string, absolute path) path to PuppetMaster/CA signed client SSL cert
+#   Defaults to 'None' ($::puppetboard::params::puppetdb_cert)
+#
+# [*puppetdb_timeout*]
+#   (int) timeout, in seconds, for connecting to PuppetDB
+#   Defaults to 20 ($::puppetboard::params::puppetdb_timeout)
+#
+# [*dev_listen_host*]
+#   (string) host that dev server binds to/listens on
+#   Defaults to '127.0.0.1' ($::puppetboard::params::dev_listen_host)
+#
+# [*dev_listen_port*]
+#   (int) port that dev server binds to/listens on
+#   Defaults to 5000 ($::puppetboard::params::dev_listen_port)
+#
+# [*unresponsive*]
+#   (int) number of hours after which a node is considered "unresponsive"
+#   Defaults to 3 ($::puppetboard::params::unresponsive)
+#
+# [*enable_query*]
+#   (string) Whether to allow the user to run raw queries against PuppetDB. 'True' or 'False'.
+#   Defaults to 'True' ($::puppetboard::params::enable_query)
+#
+# [*python_loglevel*]
+#   (string) Python logging module log level.
+#   Defaults to 'info' ($::puppetboard::params::python_loglevel)
 #
 # [*experimental*]
-#   Enable experimental features.
-#   Defaults to true
+#   (string) Enable experimental features. 'True' or 'False'.
+#   Defaults to true ($::puppetboard::params::experimental)
 #
 # === Examples
 #
@@ -89,6 +133,19 @@ class puppetboard(
     recurse => true,
   }
 
+  # Template Uses:
+  # - $puppetdb_host
+  # - $puppetdb_port
+  # - $puppetdb_ssl
+  # - $puppetdb_key
+  # - $puppetdb_cert
+  # - $puppetdb_timeout
+  # - $dev_listen_host
+  # - $dev_listen_port
+  # - $unresponsive
+  # - $enable_query
+  # - $python_loglevel
+  # - $experimental
   file { 'puppetboard/default_settings.py':
     path   => "${basedir}/puppetboard/puppetboard/default_settings.py",
     owner  => $user,
@@ -99,7 +156,6 @@ class puppetboard(
       File["${basedir}/puppetboard"],
       Python::Virtualenv["${basedir}/virtenv-puppetboard"]
     ],
-
   }
 
   python::virtualenv { "${basedir}/virtenv-puppetboard":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,9 @@
+# == Class: puppetboard::params
+#
+# Defines default values for puppetboard parameters.
+#
+# Inherited by Class['puppetboard'].
+#
 class puppetboard::params {
 
   case $::osfamily {


### PR DESCRIPTION
This adds documentation of _all_ class params, as well as doc blocks at the top of classes that didn't already have them. I've also added a "Template Uses" doc section before each template.
