### PR TITLE
PUPPETDB_SSL setting is now PUPPETDB_SSL_VERIFY

### DIFF
--- a/templates/default_settings.py.erb
+++ b/templates/default_settings.py.erb
@@ -1,6 +1,6 @@
 PUPPETDB_HOST = '<%= @puppetdb_host %>'
 PUPPETDB_PORT = <%= @puppetdb_port %>
-PUPPETDB_SSL = <%= @puppetdb_ssl %>
+PUPPETDB_SSL_VERIFY = <%= @puppetdb_ssl %>
 PUPPETDB_KEY = <%= @puppetdb_key %>
 PUPPETDB_CERT = <%= @puppetdb_cert %>
 PUPPETDB_TIMEOUT = <%= @puppetdb_timeout %>


### PR DESCRIPTION
In the current master branch of puppetboard the PUPPETDB_SSL setting in default_settings.py was renamed to PUPPETDB_SSL_VERIFY. This patch changes this in the corresponding template but doesn't touch the $puppetdb_ssl parameter of the puppetboard puppet class in init.pp for now.

Please consider changing the parameter name to $puppetdb_ssl_verify in future releases.
