### PR TITLE
Add stdlib version requirement to Modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -7,7 +7,7 @@ summary 'Install and configure PuppetBoard'
 license 'ASL 2.0'
 project_page 'https://github.com/nibalizer/puppet-module-puppetboard'
 
-dependency 'puppetlabs/stdlib'
+dependency 'puppetlabs/stdlib', '>= 3.0.0'
 dependency 'stankevich/python', '>= 1.1.4'
 dependency 'puppetlabs/vcsrepo', '>= 0.1.2'
 dependency 'puppetlabs/apache', '>=0.9.0'


### PR DESCRIPTION
I had some trouble installing your module using librarian-puppet version 0.9.10. I finally tracked it down to stdlib not having a version in Modulefile. Here's a gist illustrating the problem using the master branch of your repo and my branch that adds a version to stdlib.
https://gist.github.com/bderickson/8815816

I believe I could use the latest version of the librarian-puppet-maestrodev fork of librarian-puppet and things worked fine, but we can't upgrade to that for other reasons.

Version 3.0.0 of stdlib supports Puppet 2.7.x while later versions of stdlib drop that support, so I think specifying the version as I have should be pretty safe since versions of Puppet < 2.7 are EOL.
