### PR TITLE
Permit passing $proxy param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,10 @@
 #   (string) Python logging module log level.
 #   Defaults to 'info' ($::puppetboard::params::python_loglevel)
 #
+# [*python_proxy*]
+#   (string) HTTP proxy server to use for pip/virtualenv.
+#   Defaults to false ($::puppetboard::params::python_proxy)
+#
 # [*experimental*]
 #   (string) Enable experimental features. 'True' or 'False'.
 #   Defaults to true ($::puppetboard::params::experimental)
@@ -100,6 +104,7 @@ class puppetboard(
   $unresponsive     = $::puppetboard::params::unresponsive,
   $enable_query     = $::puppetboard::params::enable_query,
   $python_loglevel  = $::puppetboard::params::python_loglevel,
+  $python_proxy     = $::puppetboard::params::python_proxy,
   $experimental     = $::puppetboard::params::experimental,
   $revision         = $::puppetboard::params::revision,
 
@@ -173,6 +178,7 @@ class puppetboard(
     owner        => $user,
     cwd          => "${basedir}/puppetboard",
     require      => Vcsrepo["${basedir}/puppetboard"],
+    proxy        => $python_proxy,
   }
 
   if $listen == 'public' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,7 @@ class puppetboard::params {
   $unresponsive = 3
   $enable_query = 'True'
   $python_loglevel = 'info'
+  $python_proxy = false
   $experimental = 'False'
   $revision = undef
 }


### PR DESCRIPTION
Enables pip/virtualenv to traverse a HTTP proxy
