### PR TITLE
Ensure virtualenv package is 'installed' instead of 'true'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -217,7 +217,7 @@ class puppetboard(
 
   if $manage_virtualenv {
     package { $::puppetboard::params::virtualenv:
-      ensure => $manage_virtualenv
+      ensure => installed,
     }
   }
 


### PR DESCRIPTION
This makes Puppet runs more idempotent and makes for less Puppet run report noise.
