### PR TITLE
Remove Puppetfile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,8 +1,0 @@
-forge "http://forge.puppetlabs.com"
-
-mod "puppetlabs/stdlib"
-mod "puppetlabs/vcsrepo", "0.1.2"
-
-mod "python",
-  :git => "git://github.com/stankevich/puppet-python.git"
-


### PR DESCRIPTION
This repo is referenced in the Puppetfile of another larger project, where librarian-puppet fails to build the dependency tree because this Puppetfile is confusing it.
