### PR TITLE
introduce a prefix (wsgi_alias) into ::vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,28 @@ class { 'puppetboard': }
 class { 'puppetboard::apache::conf': }
 ```
 
+#### Apache (with Reverse Proxy)
+
+You can also relocate puppetboard to a sub-URI of a Virtual Host. This is
+useful if you want to reverse-proxy puppetboard, but are not planning on
+dedicating a domain just for puppetboard:
+
+```puppet
+class { 'puppetboard::apache::vhost':
+  vhost_name => 'dashes.acme',
+  wsgi_alias => '/pboard',
+}
+```
+
+In this case puppetboard will be available (on the default) on
+http://dashes.acme:5000/pboard. You can then reverse-proxy to it like so:
+
+```apache
+Redirect /pboard /pboard/
+ReverseProxy /pboard/ http://dashes.acme:5000/pboard/
+ProxyPassReverse /pboard/ http://dashes.acme:5000/pboard/
+```
+
 ### Redhat
 
 RedHat has restrictions on the /etc/apache directory that require wsgi to be configured to use /var/run.

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -11,6 +11,10 @@
 #   (string) The vhost ServerName.
 #   No default.
 #
+# [*wsgi_alias*]
+#   (string) WSGI script alias source
+#   Default: '/'
+#
 # [*port*]
 #   (int) Port for the vhost to listen on.
 #   Defaults to 5000.
@@ -33,6 +37,7 @@
 #
 class puppetboard::apache::vhost (
   $vhost_name,
+  $wsgi_alias  = '/',
   $port        = 5000,
   $threads     = 5,
   $user        = $::puppetboard::params::user,
@@ -43,7 +48,7 @@ class puppetboard::apache::vhost (
   $docroot = "${basedir}/puppetboard"
 
   $wsgi_script_aliases = {
-    '/' => "${docroot}/wsgi.py",
+    "${wsgi_alias}" => "${docroot}/wsgi.py",
   }
 
   $wsgi_daemon_process_options = {


### PR DESCRIPTION
This introduces a prefix (analogous to ::conf, we call it $wsgi_alias)
into puppetboard::apache::vhost, which allows us to relocate puppetboard
under a different sub-URI.
This is useful in reverse-proxy scenarios where we may want to collect a
number of dashboards (or other useful applications) under a single
domain, each running under a different sub-URI.

It also indirectly fixes https://github.com/nedap/puppetboard/issues/74
