### PR TITLE
Update metadata.json: fix dependency for stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0"
     },
     {
       "name": "stankevich/python",


### PR DESCRIPTION
Modulefile previously depended on >= 3.0.0, not just 3.x.
