### PR TITLE
Clean up arrow alignement and add a default case to params.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,10 +183,10 @@ class puppetboard(
   }
 
   file { $basedir:
-    ensure   => 'directory',
-    owner    => $user,
-    group    => $group,
-    mode     => '0755',
+    ensure => 'directory',
+    owner  => $user,
+    group  => $group,
+    mode   => '0755',
   }
 
   vcsrepo { "${basedir}/puppetboard":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class puppetboard::params {
       $apache_confd   = '/etc/httpd/conf.d'
       $apache_service = 'httpd'
     }
+    default: { fail("The ${::osfamily} operating system is not supported with the puppetboard module") }
   }
 
   $user  = 'puppetboard'


### PR DESCRIPTION
 Clean up arrow alignement and add a default case to params.pp in order to comply with puppet-lint
