### PR TITLE
Explicitly ensure python-dev is installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -280,6 +280,7 @@ class puppetboard(
   if $manage_virtualenv and !defined(Package[$::puppetboard::params::virtualenv]) {
     class { '::python':
       virtualenv => 'present',
+      dev        => 'present',
     }
   }
 


### PR DESCRIPTION
The stankevich/python module currently uninstalls python-dev by default. At least on CentOS, python-dev is required for virtualenv and causes a dependency failure in the puppet run.

> Execution of '/usr/bin/rpm -e python-devel-2.7.5-34.el7.x86_64' returned 1: error: \
> Failed dependencies: python2-devel is needed by (installed) python-virtualenv-1.10.1-2.el7.noarch
