### PR TITLE
Correct template for apache 2.4 and use appropriate configuration directory

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,15 +9,14 @@ class puppetboard::params {
   case $::osfamily {
     'Debian': {
       if ($::operatingsystem == ubuntu) {
-        if ($::operatingsystemrelease == '14.04') {
+        if (versioncmp($::operatingsystemrelease,'14.04')) {
           $apache_confd   = '/etc/apache2/conf.d'
         } else {
           $apache_confd = '/etc/apache2/conf-enabled'
         }
       } else {
-      $apache_confd   = '/etc/apache2/conf.d'
+        $apache_confd   = '/etc/apache2/conf.d'
       }
- 
       $apache_service = 'apache2'
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,7 @@ class puppetboard::params {
   $enable_catalog = false
   $enable_query = true
   $localise_timestamp = true
+  $offline_mode = false
   $python_loglevel = 'info'
   $python_proxy = false
   $reports_count = '10'
@@ -62,5 +63,6 @@ class puppetboard::params {
   $virtualenv = 'python-virtualenv'
   $listen = 'private'
   $apache_override = 'None'
+  $default_environment = 'production'
   $extra_settings = {}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,16 @@ class puppetboard::params {
 
   case $::osfamily {
     'Debian': {
-      if $::operatingsystem == ubuntu {
-        $apache_confd = '/etc/apache2/conf-enabled'
+      if ($::operatingsystem == ubuntu) {
+        if ($::operatingsystemrelease == '14.04') {
+          $apache_confd   = '/etc/apache2/conf.d'
+        } else {
+          $apache_confd = '/etc/apache2/conf-enabled'
+        }
       } else {
       $apache_confd   = '/etc/apache2/conf.d'
       }
+ 
       $apache_service = 'apache2'
     }
 
@@ -49,7 +54,6 @@ class puppetboard::params {
   $enable_catalog = false
   $enable_query = true
   $localise_timestamp = true
-  $offline_mode = false
   $python_loglevel = 'info'
   $python_proxy = false
   $reports_count = '10'
@@ -58,6 +62,5 @@ class puppetboard::params {
   $virtualenv = 'python-virtualenv'
   $listen = 'private'
   $apache_override = 'None'
-  $default_environment = 'production'
   $extra_settings = {}
 }

--- a/templates/apache/conf.erb
+++ b/templates/apache/conf.erb
@@ -4,6 +4,11 @@ WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
 <Directory <%= @docroot -%>>
     WSGIProcessGroup puppetboard
     WSGIApplicationGroup %{GLOBAL}
-    Order deny,allow
-    Allow from all
+    <IfVersion < 2.4>
+      Order allow,deny
+      Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+      Require all granted
+    </IfVersion>
 </Directory>


### PR DESCRIPTION
This fork modifies the templates/apache/conf.erb file to put conditionals around parts of the syntax to make it compatible with Apache 2.4.

Params is also modified so that (at least on Ubuntu 14.04 running Apache 2.4) it uses conf.d instead of conf-enabled. I don't know that other versions of Ubuntu use conf-enabled. I know this setup does not.
