### PR TITLE
Add apache file auth support

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -68,7 +68,7 @@
 #   No default ($::puppetboard::params::ldap_url)
 #
 # [*ldap_bind_authoritative]
-#   (string) Determines if other authentication providers are used 
+#   (string) Determines if other authentication providers are used
 #            when a user can be mapped to a DN but the server cannot bind with the credentials
 #   No default ($::puppetboard::params::ldap_bind_authoritative)
 class puppetboard::apache::vhost (
@@ -87,8 +87,15 @@ class puppetboard::apache::vhost (
   $ldap_bind_dn             = $::puppetboard::params::ldap_bind_dn,
   $ldap_bind_password       = $::puppetboard::params::ldap_bind_password,
   $ldap_url                 = $::puppetboard::params::ldap_url,
-  $ldap_bind_authoritative  = $::puppetboard::params::ldap_bind_authoritative
-
+  $ldap_bind_authoritative  = $::puppetboard::params::ldap_bind_authoritative,
+  $enable_file_auth         = $::puppetboard::params::enable_file_auth,
+  $file_auth_allowoverride  = $::puppetboard::params::file_auth_allowoverride,
+  $file_auth_basic_provider = $::puppetboard::params::file_auth_basic_provider,
+  $file_auth_name           = $::puppetboard::params::file_auth_name,
+  $file_auth_options        = $::puppetboard::params::file_auth_options,
+  $file_auth_require        = $::puppetboard::params::file_auth_require,
+  $file_auth_type           = $::puppetboard::params::file_auth_type,
+  $file_auth_user_file      = $::puppetboard::params::file_auth_user_file,
 ) inherits ::puppetboard::params {
 
   $docroot = "${basedir}/puppetboard"
@@ -133,7 +140,24 @@ class puppetboard::apache::vhost (
     $ldap_additional_includes = undef
     $ldap_require = undef
   }
+
+  if $enable_file_auth {
+    $directories = [
+      {
+        'allowoverride'       => $file_auth_allowoverride,
+        'auth_basic_provider' => $file_auth_basic_provider,
+        'auth_name'           => $file_auth_name,
+        'auth_require'        => $file_auth_require,
+        'auth_type'           => $file_auth_type,
+        'auth_user_file'      => $file_auth_user_file,
+        'options'             => $file_auth_options,
+        'path'                => $docroot,
+      },
+    ]
+  }
+
   ::apache::vhost { $vhost_name:
+    directories                 => $directories,
     port                        => $port,
     docroot                     => $docroot,
     ssl                         => $ssl,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,4 +64,12 @@ class puppetboard::params {
   $ldap_bind_password = undef
   $ldap_url = undef
   $ldap_bind_authoritative = undef
+  $enable_file_auth = false
+  $file_auth_allowoverride = 'None'
+  $file_auth_basic_provider = 'file'
+  $file_auth_name = 'PuppetBoard'
+  $file_auth_options = 'Indexes FollowSymLinks MultiViews'
+  $file_auth_require = 'user puppetboard pboard puppet'
+  $file_auth_type = 'Basic'
+  $file_auth_user_file = "${basedir}/.htpasswd"
 }


### PR DESCRIPTION
This patch adds support for Apache file auth (htpasswd).

I've tried to run the acceptance tests but I've run into a number of errors.
Once I got it to actually boot a vm none of the tests were run:

```
==> ubuntu-server-1604-x64: Machine booted and ready!
==> ubuntu-server-1604-x64: Checking for guest additions in VM...
==> ubuntu-server-1604-x64: Setting hostname...
==> ubuntu-server-1604-x64: Configuring and enabling network interfaces...
==> ubuntu-server-1604-x64: Mounting shared folders...
   ubuntu-server-1604-x64: /vagrant => /Users/tom/Documents/Inuits/Projects/21net/vagrant-sncf/puppetlabs/code/environments/production/modules/puppetboard/.vagrant/beaker_vagrant_files/ubuntu-server-1604-x64.yml
Disabling updates.puppetlabs.com by modifying hosts file to resolve updates to 127.0.0.1 on ubuntu-server-1604-x64
No tests to run for suite 'pre_suite'
No tests to run for suite 'tests'
No tests to run for suite 'post_suite'
No tests to run for suite 'pre_cleanup'
Cleanup: cleaning up after successful run
Destroying vagrant boxes
==> ubuntu-server-1604-x64: Forcing shutdown of VM...
==> ubuntu-server-1604-x64: Destroying VM and associated drives...
Beaker completed successfully, thanks.
```

If anyone could tell me how to successfully run the tests I'll gladly add some acceptance tests to this PR.
