### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,13 +57,13 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 < 5.0.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "stankevich/python",
@@ -71,7 +71,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 0.1.2 < 2.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata