### PR TITLE
Update the puppetdb_ssl_verify setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ class { 'puppetboard':
   puppetdb_host       => 'puppetdb.example.com',
   puppetdb_port       => '8081',
   puppetdb_key        => "${ssl_dir}/private_keys/${puppetboard_certname}.pem",
-  puppetdb_ssl_verify => true,
+  puppetdb_ssl_verify => "${ssl_dir}/certs/ca.pem",
   puppetdb_cert       => "${ssl_dir}/certs/${puppetboard_certname}.pem",
 }
 ```
@@ -253,7 +253,7 @@ class { 'puppetboard':
   puppetdb_host       => 'puppetdb.example.com',
   puppetdb_port       => '8081',
   puppetdb_key        => "${ssl_dir}/private_keys/${puppetboard_certname}.pem",
-  puppetdb_ssl_verify => true,
+  puppetdb_ssl_verify => "${ssl_dir}/certs/ca.pem",
   puppetdb_cert       => "${ssl_dir}/certs/${puppetboard_certname}.pem",
 }
 ```


### PR DESCRIPTION
The opposite of False in this case is not True, but the location of the CA file.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
