### PR TITLE
Sort extra_settings to prevent churn

### DIFF
--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -63,6 +63,6 @@ DEFAULT_ENVIRONMENT = '<%= @default_environment %>'
 <% if @reports_count -%>
 REPORTS_COUNT = <%= @reports_count %>
 <% end -%>
-<% @extra_settings.each_pair do |key, value| -%>
-<%= key %> = <%= value %>
+<% @extra_settings.keys.sort.each do |key| -%>
+<%= key %> = <%= @extra_settings[key] %>
 <% end -%>


### PR DESCRIPTION
Sort the extra_settings hash keys so that they are processed in a consistent order preventing unnecessary changes in the generated file. 