### PR TITLE
#166: Removed direct dependencies on EPEL module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,6 @@ fixtures:
     concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
     vcsrepo: "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     python: "git://github.com/stankevich/puppet-python.git"
-    epel: "git://github.com/stahnma/puppet-module-epel.git"
     apache: 'git://github.com/puppetlabs/puppetlabs-apache.git'
   symlinks:
     puppetboard: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -72,10 +72,6 @@
     {
       "name": "puppetlabs/vcsrepo",
       "version_requirement": ">= 1.3.1 < 2.0.0"
-    },
-    {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ]
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,15 +3,7 @@ require 'spec_helper_acceptance'
 describe 'puppetboard class' do
   context 'default parameters' do
     hosts.each do |host|
-      if fact('osfamily') == 'RedHat'
-        if fact('architecture') == 'amd64'
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        else
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        end
-      end
       on host, 'puppet module install puppetlabs/apache'
-      install_package host, 'python-virtualenv'
       install_package host, 'git'
     end
 
@@ -38,15 +30,7 @@ describe 'puppetboard class' do
 
   context 'default parameters' do
     hosts.each do |host|
-      if fact('osfamily') == 'RedHat'
-        if fact('architecture') == 'amd64'
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        else
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        end
-      end
       on host, 'puppet module install puppetlabs/apache'
-      install_package host, 'python-virtualenv'
       install_package host, 'git'
     end
 
@@ -83,15 +67,7 @@ describe 'puppetboard class' do
 
   context 'default parameters' do
     hosts.each do |host|
-      if fact('osfamily') == 'RedHat'
-        if fact('architecture') == 'amd64'
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        else
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        end
-      end
       on host, 'puppet module install puppetlabs/apache'
-      install_package host, 'python-virtualenv'
       install_package host, 'git'
     end
 
@@ -120,15 +96,7 @@ describe 'puppetboard class' do
 
   context 'default parameters' do
     hosts.each do |host|
-      if fact('osfamily') == 'RedHat'
-        if fact('architecture') == 'amd64'
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        else
-          on host, 'wget http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm; rpm -ivh epel-release-6-8.noarch.rpm'
-        end
-      end
       on host, 'puppet module install puppetlabs/apache'
-      install_package host, 'python-virtualenv'
       install_package host, 'git'
     end
 


### PR DESCRIPTION
Removed direct dependencies on EPEL module and manual install of EPEL in rspec to let Python module do it via 'manage_virtualenv' => true param (which is already set to true)