### PR TITLE
Add boolean to control EPEL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,10 @@
 #   (string) HTTP index server to use for pip/virtualenv.
 #   Defaults to false ($::puppetboard::params::python_index)
 #
+# [*python_use_epel*]
+#   (bool) Whether the Python class will use attempt to manage EPEL or not.
+#   Defaults to undef.
+#
 # [*default_environment*]
 #   (string) set the default environment
 #   Defaults to production ($::puppetboard::params::default_environment
@@ -178,6 +182,7 @@ class puppetboard(
   Puppetboard::Syslogpriority $python_loglevel                = $::puppetboard::params::python_loglevel,
   Optional[String] $python_proxy                              = undef,
   Optional[String] $python_index                              = undef,
+  Optional[Boolean] $python_use_epel                          = undef,
   Boolean $experimental                                       = $::puppetboard::params::experimental,
   Optional[String] $revision                                  = undef,
   Boolean $manage_selinux                                     = $::puppetboard::params::manage_selinux,
@@ -277,6 +282,7 @@ class puppetboard(
     class { '::python':
       virtualenv => 'present',
       dev        => 'present',
+      use_epel   => $python_use_epel,
     }
   }
 

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -17,6 +17,13 @@ describe 'puppetboard', type: :class do
       it { is_expected.to contain_user('puppetboard') }
       it { is_expected.to contain_python__virtualenv('/srv/puppetboard/virtenv-puppetboard') }
       it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }
+      context 'with python_use_epel=>false' do
+        let :params do
+          { python_use_epel: false, manage_virtualenv: true }
+        end
+
+        it { is_expected.to contain_class('python').with_use_epel(false) }
+      end
     end
   end
 end


### PR DESCRIPTION
Add boolean to explicitly control whether Class[python] tries to manage EPEL or not - useful for environments that mirror EPEL internally.

This directly conflicts with #176 - but my commit is backwards compatible as EPEL will continue to be managed by default.

Note the Rubocop failure is on spec/spec_helper_acceptance.rb which is probably managed by Voxpupuli's Module Sync, so while I *could* make the Rubocop warning go away, my change will be overwritten by any msync from upstream :-)