### PR TITLE
Switch to puppet_install_helper (and fix rubocop warning in process)

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,9 +1,7 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-hosts.each do |_host|
-  # Install Puppet
-  install_puppet
-end
+run_puppet_install_helper
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
@ekohl I think we should still fix the build failure (and re-run tests) before merging #183 