### PR TITLE
Make EPEL soft dependency per style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ which will cause an error trying to install puppetboard.
 
 Note that this module no longer explicitly requires the puppetlabs apache module. If you want to use the apache functionality of this module you will have to specify that the apache module is installed with:
 
-
     puppet module install puppetlabs-apache
+
+On RedHat type systems, EPEL may also be a requirement.
 
 This module also requires the ``git`` and ``virtualenv`` packages. These can be enabled in the module by:
 

--- a/metadata.json
+++ b/metadata.json
@@ -72,10 +72,6 @@
     {
       "name": "puppetlabs/vcsrepo",
       "version_requirement": ">= 1.3.1 < 2.0.0"
-    },
-    {
-      "name": "stahnma/epel",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ]
 }


### PR DESCRIPTION
EPEL should be a documented soft dependency rather than a requirement in `metadata.json`
https://docs.puppet.com/puppet/5.1/style_guide.html#dependencies
