### PR TITLE
Update (and run in Travis) acceptance tests, fix formatting in LDAP templates

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,6 @@
 ---
 .travis.yml:
-    secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
+  secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
+  docker_sets:
+    - set: docker/ubuntu-16.04
+    - set: docker/centos-7

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,18 @@ script:
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.1
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
+    services: docker
+    sudo: required
   - rvm: 2.1.9
     bundler_args: --without system_tests development
     env: PUPPET_VERSION="~> 4.0" CHECK=test

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :system_tests do
   end
   gem 'serverspec',                    :require => false
   gem 'beaker-puppet_install_helper',  :require => false
+  gem 'beaker-module_install_helper',  :require => false
 end
 
 
@@ -62,7 +63,7 @@ end
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion.to_s, :require => false, :groups => [:test]
 else
-gem 'facter', :require => false, :groups => [:test]
+  gem 'facter', :require => false, :groups => [:test]
 end
 
 ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 5.0' : puppetversion = ENV['PUPPET_VERSION'].to_s

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,23 +1,16 @@
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
 run_puppet_install_helper
+install_module
+install_module_dependencies
+
+# Install additional modules for soft deps
+install_module_from_forge('puppetlabs-apache', '>= 2.1.0 < 3.0.0')
+install_module_from_forge('stahnma-epel', '>= 1.2.2 < 2.0.0')
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    # Install module
-    puppet_module_install(source: proj_root, module_name: 'puppetboard')
-    hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'stankevich-python'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppetlabs-vcsrepo'), acceptable_exit_codes: [0, 1]
-    end
-  end
 end

--- a/templates/apache/conf.erb
+++ b/templates/apache/conf.erb
@@ -12,8 +12,7 @@ WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
       Require all granted
     </IfVersion>
 </Directory>
-## Puppet data <%= @ldap_bind_dn -%>
-<% if @enable_ldap_auth != false %> 
+<% if @enable_ldap_auth -%>
 <LocationMatch ^/puppetboard>
    AuthType Basic
    AuthName "Login to puppetboard"
@@ -21,18 +20,18 @@ WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
    Allow from All
 
    AuthBasicProvider ldap
-   <% if @ldap_bind_dn != false %> 
-   AuthLDAPBindDN <%= @ldap_bind_dn -%>
-   <% end %>
-   <% if @ldap_bind_password != false %> 
-   AuthLDAPBindPassword <%= @ldap_bind_password -%>
-   <% end %>
-   <% if @ldap_url != false %> 
-   AuthLDAPURL <%= @ldap_url -%>
-   <% end %>
-   <% if @ldap_bind_authoritative != false %> 
+   <%- if @ldap_bind_dn -%>
+   AuthLDAPBindDN "<%= @ldap_bind_dn -%>"
+   <%- end -%>
+   <%- if @ldap_bind_password -%>
+   AuthLDAPBindPassword "<%= @ldap_bind_password -%>"
+   <%- end -%>
+   <%- if @ldap_url != false -%>
+   AuthLDAPURL "<%= @ldap_url -%>"
+   <%- end -%>
+   <%- if @ldap_bind_authoritative -%>
    AuthLDAPBindAuthoritative <%= @ldap_bind_authoritative -%>
-   <% end %>
+   <%- end -%>
    Require valid-user
 </LocationMatch>
-<% end %>
+<% end -%>

--- a/templates/apache/ldap.erb
+++ b/templates/apache/ldap.erb
@@ -5,17 +5,17 @@
    Allow from All
 
    AuthBasicProvider ldap
-   <% if @ldap_bind_dn != false %>
-   AuthLDAPBindDN <%= @ldap_bind_dn -%>
-   <% end %>
-   <% if @ldap_bind_password != false %>
-   AuthLDAPBindPassword <%= @ldap_bind_password -%>
-   <% end %>
-   <% if @ldap_url != false %>
-   AuthLDAPURL <%= @ldap_url -%>
-   <% end %>
-   <% if @ldap_bind_authoritative != false %>
+   <%- if @ldap_bind_dn -%>
+   AuthLDAPBindDN "<%= @ldap_bind_dn -%>"
+   <%- end -%>
+   <%- if @ldap_bind_password -%>
+   AuthLDAPBindPassword "<%= @ldap_bind_password -%>"
+   <%- end -%>
+   <%- if @ldap_url -%> 
+   AuthLDAPURL "<%= @ldap_url -%>"
+   <%- end -%>
+   <%- if @ldap_bind_authoritative -%>
    AuthLDAPBindAuthoritative <%= @ldap_bind_authoritative -%>
-   <% end %>
+   <%- end -%>
    Require valid-user
 </LocationMatch>


### PR DESCRIPTION
This should fix the acceptance tests, and configure them to run in Travis.
It also adds (double) quotes around some LDAP params and suppresses newlines in the LDAP config.

Acceptance tests were refactored to use module_install_helper and to handle dependencies in the spec_helper rather than in the spec itself. I switched the Apache vhost to port 80 from 5000 to avoid having to deal with Selinux.

It does expose some things (like the LDAP config) that should be better tested in the class spec and better documented; I have not fixed either of those things here, but this should at least give us a bit more visibility into problems when changes are made, and avoid having the acceptance tests get so out of date and broken relative to the code.

There's also room for more improvements if someone cares, like pushing actual fake certs to the node and testing connection w/ SSL enabled.