### PR TITLE
Set custom vhost parameters. for example Basic Auth

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -87,7 +87,8 @@ class puppetboard::apache::vhost (
   Optional[String] $ldap_bind_dn            = undef,
   Optional[String] $ldap_bind_password      = undef,
   Optional[String] $ldap_url                = undef,
-  Optional[String] $ldap_bind_authoritative = undef
+  Optional[String] $ldap_bind_authoritative = undef,
+  Optional[Hash] $custom_apache_parameters  = {},
 ) inherits ::puppetboard::params {
 
   $docroot = "${basedir}/puppetboard"
@@ -143,6 +144,7 @@ class puppetboard::apache::vhost (
     override                    => $override,
     require                     => [ File["${docroot}/wsgi.py"], $ldap_require ],
     notify                      => Service[$::puppetboard::params::apache_service],
+    *                           => $custom_apache_parameters,
   }
   File["${basedir}/puppetboard/settings.py"] ~> Service['httpd']
 }

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -88,7 +88,7 @@ class puppetboard::apache::vhost (
   Optional[String] $ldap_bind_password      = undef,
   Optional[String] $ldap_url                = undef,
   Optional[String] $ldap_bind_authoritative = undef,
-  Optional[Hash] $custom_apache_parameters  = {},
+  Hash $custom_apache_parameters            = {},
 ) inherits ::puppetboard::params {
 
   $docroot = "${basedir}/puppetboard"


### PR DESCRIPTION
currently it is not possible to add custom parameters to the vhost created for puppetboard.
to configure a simple `Auth Basic` the whole vhost has to be created by oneself.

with this PR it is possible to pipe all `::apache::vhost parameters` through `::puppetboard::apache::vhost` with `$custom_apache_parameters`

```
puppetboard::apache::vhost::vhost_name: "%{facts.networking.fqdn}"
puppetboard::apache::vhost::port:       443
puppetboard::apache::vhost::ssl:        true
puppetboard::apache::vhost::ssl_cert:   /etc/ssl/localcerts/xxx.crt
puppetboard::apache::vhost::ssl_key:    /etc/ssl/private/xxx.key
puppetboard::apache::vhost::custom_apache_parameters:
  directories:
    -
      provider: Directory
      path:  '/srv/puppetboard/puppetboard'
      custom_fragment: |
        AuthType Basic
        AuthName "Restricted Files"
        AuthBasicProvider file
        AuthUserFile "/etc/apache2/htpasswd"
        Require user admin
        Options Indexes FollowSymLinks MultiViews
        AllowOverride None
```


