### PR TITLE
Group should be a system group.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,6 +200,7 @@ class puppetboard(
   if $manage_group {
     group { $group:
       ensure => present,
+      system => true,
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
Hello,

I think the group should be created as a system group, we ran into issues with gid collision with our users.