### PR TITLE
Fix apache conf dir for Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,11 +9,7 @@ class puppetboard::params {
   case $facts['os']['family'] {
     'Debian': {
       if ($facts['os']['name'] == 'ubuntu') {
-        if (versioncmp($facts['os']['release']['full'],'14.04')) {
-          $apache_confd   = '/etc/apache2/conf.d'
-        } else {
-          $apache_confd = '/etc/apache2/conf-enabled'
-        }
+        $apache_confd = '/etc/apache2/conf-enabled'
       } else {
         $apache_confd   = '/etc/apache2/conf.d'
       }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,7 +5,7 @@ describe 'puppetboard class' do
   when 'RedHat'
     apache_conf_file = '/etc/httpd/conf.d/puppetboard.conf'
   when 'Debian'
-    apache_conf_file = '/etc/apache2/conf.d/puppetboard.conf'
+    apache_conf_file = '/etc/apache2/conf-enabled/puppetboard.conf'
   end
 
   context 'default parameters' do


### PR DESCRIPTION
Ubuntu 12.04 uses conf.d/, and 14.04 onwards uses conf-enabled/

Fixes: #204 

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
