### PR TITLE
fix ProxyPass example

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ http://dashes.acme:5000/pboard. You can then reverse-proxy to it like so:
 
 ```apache
 Redirect /pboard /pboard/
-ReverseProxy /pboard/ http://dashes.acme:5000/pboard/
+ProxyPass /pboard/ http://dashes.acme:5000/pboard/
 ProxyPassReverse /pboard/ http://dashes.acme:5000/pboard/
 ```
 


### PR DESCRIPTION
I think the proxy example is a typo, the correct directive is `ProxyPass`

https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html