### PR TITLE
Document that apache::mod::version should be included

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ RedHat/CentOS has restrictions on the /etc/apache directory that require wsgi to
 
 # Configure Apache on this server
 class { 'apache': }
+class { 'apache::mod::version': }
 class { 'apache::mod::wsgi':
   wsgi_socket_prefix => "/var/run/wsgi",
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Puppetboard.conf will not work without mod_version apache module. That module is not enabled by default on some CentOS 7 Vagrant boxes. Other minimal CentOS 7 installations may also be affected. This PR modifies README.md to suggest that ::apache::mod::version should be included in addition to ::apache::mod::wsgi.