### PR TITLE
change python provider to puppet/python

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,7 @@ fixtures:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
     concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
     vcsrepo: "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
-    python: "git://github.com/stankevich/puppet-python.git"
+    python: "git://github.com/voxpupuli/puppet-python.git"
     epel: "git://github.com/stahnma/puppet-module-epel.git"
     apache: 'git://github.com/puppetlabs/puppetlabs-apache.git'
   symlinks:

--- a/metadata.json
+++ b/metadata.json
@@ -60,8 +60,8 @@
       "version_requirement": ">= 4.13.1 < 5.0.0"
     },
     {
-      "name": "stankevich/python",
-      "version_requirement": ">= 1.12.0 < 2.0.0"
+      "name": "puppet/python",
+      "version_requirement": ">= 1.12.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
#### Pull Request (PR) description
stankevich/python has been deprecated. This PR replaces it with puppet/python

#### This Pull Request (PR) fixes the following issues
Fixes #215 

It's a pretty straightforward change and seems to work in my (limited) environment. I am not expert enough to be able to run unit tests.