### PR TITLE
Fix Apache configuration fragment directory on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,7 @@ class puppetboard::params {
 
   case $facts['os']['family'] {
     'Debian': {
-      if ($facts['os']['name'] == 'ubuntu') {
-        $apache_confd = '/etc/apache2/conf-enabled'
-      } else {
-        $apache_confd   = '/etc/apache2/conf.d'
-      }
+      $apache_confd = '/etc/apache2/conf-enabled'
       $apache_service = 'apache2'
     }
 


### PR DESCRIPTION
Debian has placed Apache configuration fragments into /etc/apache2/conf-enabled
since Debian 8, so /etc/apache2/conf.d is doomed to fail.