### PR TITLE
rename LDAP include fragment file extension so it doesn't get include…

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -68,7 +68,7 @@
 #   No default ($::puppetboard::params::ldap_url)
 #
 # [*ldap_bind_authoritative]
-#   (string) Determines if other authentication providers are used 
+#   (string) Determines if other authentication providers are used
 #            when a user can be mapped to a DN but the server cannot bind with the credentials
 #   No default ($::puppetboard::params::ldap_bind_authoritative)
 #
@@ -125,9 +125,9 @@ class puppetboard::apache::vhost (
   }
 
   if $enable_ldap_auth {
-    $ldap_additional_includes = [ "${::puppetboard::params::apache_confd}/puppetboard-ldap.conf" ]
-    $ldap_require = File["${::puppetboard::params::apache_confd}/puppetboard-ldap.conf"]
-    file { "${::puppetboard::params::apache_confd}/puppetboard-ldap.conf":
+    $ldap_additional_includes = [ "${::puppetboard::params::apache_confd}/puppetboard-ldap.part" ]
+    $ldap_require = File["${::puppetboard::params::apache_confd}/puppetboard-ldap.part"]
+    file { "${::puppetboard::params::apache_confd}/puppetboard-ldap.part":
       ensure  => present,
       owner   => 'root',
       group   => 'root',


### PR DESCRIPTION
…d into the default VHost by puppetlabs-apache's include of all *.conf files

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
