### PR TITLE
rename LDAP fragment to avoid including in default vhost

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -68,7 +68,7 @@
 #   No default ($::puppetboard::params::ldap_url)
 #
 # [*ldap_bind_authoritative]
-#   (string) Determines if other authentication providers are used 
+#   (string) Determines if other authentication providers are used
 #            when a user can be mapped to a DN but the server cannot bind with the credentials
 #   No default ($::puppetboard::params::ldap_bind_authoritative)
 #
@@ -125,9 +125,9 @@ class puppetboard::apache::vhost (
   }
 
   if $enable_ldap_auth {
-    $ldap_additional_includes = [ "${::puppetboard::params::apache_confd}/puppetboard-ldap.conf" ]
-    $ldap_require = File["${::puppetboard::params::apache_confd}/puppetboard-ldap.conf"]
-    file { "${::puppetboard::params::apache_confd}/puppetboard-ldap.conf":
+    $ldap_additional_includes = [ "${::puppetboard::params::apache_confd}/puppetboard-ldap.part" ]
+    $ldap_require = File["${::puppetboard::params::apache_confd}/puppetboard-ldap.part"]
+    file { "${::puppetboard::params::apache_confd}/puppetboard-ldap.part":
       ensure  => present,
       owner   => 'root',
       group   => 'root',


### PR DESCRIPTION
When using LDAP auth on the puppetboard VHost, a file is created called `puppetboard-ldap.conf`.  The file extension `.conf` is a bad choice, as this matches the inclusion glob that the puppetlabs-apache module creates:

```
Include "/etc/httpd/conf.d/*.conf"
```

This results in the `puppetboard-ldap.conf` being included in both the Puppet Board VHost *and* the default / top-level Apache config.  If using Puppet Board on an Apache server that has other VHosts, it effectively applies the same LDAP restrictions to all other VHosts.

This patch renames the file to `puppetboard-ldap.part` to avoid the glob, and avoid the problem.