### PR TITLE
rename LDAP include fragment file extension so it doesn't get include…

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -68,7 +68,7 @@
 #   No default ($::puppetboard::params::ldap_url)
 #
 # [*ldap_bind_authoritative]
-#   (string) Determines if other authentication providers are used 
+#   (string) Determines if other authentication providers are used
 #            when a user can be mapped to a DN but the server cannot bind with the credentials
 #   No default ($::puppetboard::params::ldap_bind_authoritative)
 #
@@ -125,10 +125,11 @@ class puppetboard::apache::vhost (
   }
 
   if $enable_ldap_auth {
-    $ldap_additional_includes = [ "${puppetboard::params::apache_confd}/puppetboard-ldap.conf" ]
-    $ldap_require = File["${puppetboard::params::apache_confd}/puppetboard-ldap.conf"]
-    file { "${puppetboard::params::apache_confd}/puppetboard-ldap.conf":
+    $ldap_additional_includes = [ "${puppetboard::params::apache_confd}/puppetboard-ldap.part" ]
+    $ldap_require = File["${puppetboard::params::apache_confd}/puppetboard-ldap.part"]
+    file { 'puppetboard-ldap.part':
       ensure  => present,
+      path    => "${puppetboard::params::apache_confd}/puppetboard-ldap.part",
       owner   => 'root',
       group   => 'root',
       content => template('puppetboard/apache/ldap.erb'),

--- a/spec/classes/vhost_spec.rb
+++ b/spec/classes/vhost_spec.rb
@@ -4,8 +4,9 @@ describe 'puppetboard::apache::vhost' do
   describe 'default params' do
     let :params do
       {
-        'vhost_name' => 'puppetboard.local',
-        'port'       => 80
+        'vhost_name'       => 'puppetboard.local',
+        'port'             => 80,
+        'enable_ldap_auth' => true
       }
     end
     let(:pre_condition) do
@@ -32,9 +33,8 @@ describe 'puppetboard::apache::vhost' do
           ).that_requires('File[/srv/puppetboard/puppetboard/wsgi.py]')
         end
         it do
-          is_expected.to contain_concat('25-puppetboard.local.conf').with(
-            'ensure' => 'present',
-            'path'   => '/etc/apache2/sites-available/25-puppetboard.local.conf'
+          is_expected.to contain_file('puppetboard-ldap.part').with(
+            'ensure' => 'present'
           )
         end
       end


### PR DESCRIPTION
Recreating #241 because I made a mess of the last PR.

When using LDAP auth on the puppetboard VHost, a file is created called puppetboard-ldap.conf. The file extension .conf is a bad choice, as this matches the inclusion glob that the puppetlabs-apache module creates:

> Include "/etc/httpd/conf.d/*.conf"

This results in the puppetboard-ldap.conf being included in both the Puppet Board VHost and the default / top-level Apache config. If using Puppet Board on an Apache server that has other VHosts, it effectively applies the same LDAP restrictions to all other VHosts.

This patch renames the file to puppetboard-ldap.part to avoid the glob, and avoid the problem.