### PR TITLE
add virtualenv_cmd parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,10 @@
 #   (string) Python version to use in virtualenv if manage_virtualenv is true.
 #   Defaults to 'system'
 #
+# [*virtualenv_cmd*]
+#   (string) virtualenv command name to use, instead of default 'virtualenv'
+#   Defaults to undef
+#
 # [*manage_user*]
 #   (bool) If true, manage (create) this group. If false do nothing.
 #   Defaults to true
@@ -195,6 +199,7 @@ class puppetboard(
   Boolean $manage_git                                         = false,
   Boolean $manage_virtualenv                                  = false,
   String[1]  $virtualenv_version                              = $puppetboard::params::virtualenv_version,
+  Optional[String] $virtualenv_cmd                            = undef,
   Integer $reports_count                                      = $puppetboard::params::reports_count,
   String $default_environment                                 = $puppetboard::params::default_environment,
   String $listen                                              = $puppetboard::params::listen,
@@ -264,6 +269,7 @@ class puppetboard(
     require      => Vcsrepo["${basedir}/puppetboard"],
     proxy        => $python_proxy,
     index        => $python_index,
+    virtualenv   => $virtualenv_cmd,
   }
 
   if $listen == 'public' {

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 1.12.0 < 4.0.0"
+      "version_requirement": ">= 3.0.1 < 4.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
#### Pull Request (PR) description

Provide a capability to specify alternative name for virtualenv command, for example, virtualenv-3.6
This is complimentary option for virtualenv_version parameter

The following hiera data siwthes to python 3.6 on RHEL7, for example

```
python::version: python36
puppetboard::virtualenv_version: '3.6'
puppetboard::virtualenv_cmd: virtualenv-3.6
```
