### PR TITLE
make wsgi.py python3 compatible

### DIFF
--- a/templates/wsgi.py.erb
+++ b/templates/wsgi.py.erb
@@ -5,7 +5,7 @@ import sys
 
 os.environ['PUPPETBOARD_SETTINGS'] = '<%= @basedir %>/puppetboard/settings.py'
 activate_this = '<%= @basedir %>/virtenv-puppetboard/bin/activate_this.py'
-execfile(activate_this, dict(__file__=activate_this))
+exec(open(activate_this,"rb").read(), dict(__file__=activate_this))
 
 me = os.path.dirname(os.path.abspath(__file__))
 # Add us to the PYTHONPATH/sys.path if we're not on it


### PR DESCRIPTION
#### Pull Request (PR) description

python3 dropped support for execfile function, combination of exec/open works well on both python2 and python3
