### PR TITLE
Fix things that didn't work with py3.

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -108,9 +108,10 @@ class puppetboard::apache::vhost (
   }
 
   $wsgi_daemon_process_options = {
-    threads => $threads,
-    group   => $group,
-    user    => $user,
+    threads     => $threads,
+    group       => $group,
+    user        => $user,
+    python-home => "${basedir}/virtenv-puppetboard",
   }
 
   file { "${docroot}/wsgi.py":

--- a/templates/apache/conf.erb
+++ b/templates/apache/conf.erb
@@ -1,4 +1,4 @@
-WSGIDaemonProcess puppetboard user=<%= @user -%> group=<%= @user -%> threads=<%= @threads %> maximum-requests=<%= @max_reqs %>
+WSGIDaemonProcess puppetboard user=<%= @user -%> group=<%= @user -%> threads=<%= @threads %> maximum-requests=<%= @max_reqs %> python-home=<%= @base_dir %>/virtenv-puppetboard
 WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
 
 <Directory <%= @docroot -%>>

--- a/templates/wsgi.py.erb
+++ b/templates/wsgi.py.erb
@@ -5,7 +5,7 @@ import sys
 
 os.environ['PUPPETBOARD_SETTINGS'] = '<%= @basedir %>/puppetboard/settings.py'
 activate_this = '<%= @basedir %>/virtenv-puppetboard/bin/activate_this.py'
-execfile(activate_this, dict(__file__=activate_this))
+exec(compile(open(activate_this, "rb").read(), activate_this, 'exec'), globals(), locals())
 
 me = os.path.dirname(os.path.abspath(__file__))
 # Add us to the PYTHONPATH/sys.path if we're not on it


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix the apache and wsgi configs to work with python3.
This will break python2 because locals and globals change to a function in python 3. I assume that python2 compat isn't important given that both puppetboard and python itself aren't supporting python 2 anymore.

#### This Pull Request (PR) fixes the following issues
Fixes #252 
