### PR TITLE
Fix apache2 conf.d directory location for all recent Debian versions

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,11 +8,7 @@ class puppetboard::params {
 
   case $facts['os']['family'] {
     'Debian': {
-      if ($facts['os']['name'] == 'ubuntu') {
-        $apache_confd = '/etc/apache2/conf-enabled'
-      } else {
-        $apache_confd   = '/etc/apache2/conf.d'
-      }
+      $apache_confd = '/etc/apache2/conf-enabled'
       $apache_service = 'apache2'
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,9 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Debian 8-10 use /etc/apache2/conf-enabled as the configuration fragment
directory, just like all recent Ubuntus.

#### This Pull Request (PR) fixes the following issues

The default logic in this module is wrong on all semi-recent Debians (8-10) and causes failure when trying apply the Puppetboard-specific Apache2 configurations.