### PR TITLE
chore: bump python dependency to < 5.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 1.12.0 < 4.0.0"
+      "version_requirement": ">= 1.12.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
#### Pull Request (PR) description

This PR raises the dependency on puppet-python to < 5.0.0.

#### This Pull Request (PR) fixes the following issues

None specifically.
