### PR TITLE
Fix virtualenv_version comment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,7 +124,7 @@
 #   Defaults to false
 #
 # [*virtualenv_version*]
-#   (string) Python version to use in virtualenv if manage_virtualenv is true.
+#   (string) Python version to use in virtualenv.
 #   Defaults to 'system'
 #
 # [*manage_user*]


### PR DESCRIPTION
#### Pull Request (PR) description
The value of `$virtualenv_version` is used by the virtualenv resource regardless of the `$manage_virtualenv value`.

#### This Pull Request (PR) fixes the following issues
n/a