### PR TITLE
Add possibility to configure intermediate certs

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -31,6 +31,10 @@
 #   (string, absolute path) Path to server SSL key
 #   No default.
 #
+# [*ssl_chain*]
+#   (string, absolute path) Path to server SSL chain
+#   No default.
+#
 # [*threads*]
 #   (int) Number of WSGI threads to use.
 #   Defaults to 5
@@ -86,6 +90,7 @@ class puppetboard::apache::vhost (
   Boolean $ssl                              = false,
   Optional[Stdlib::AbsolutePath] $ssl_cert  = undef,
   Optional[Stdlib::AbsolutePath] $ssl_key   = undef,
+  Optional[Stdlib::AbsolutePath] $ssl_chain = undef,
   Integer $threads                          = 5,
   String $user                              = $puppetboard::params::user,
   String $group                             = $puppetboard::params::group,
@@ -147,6 +152,7 @@ class puppetboard::apache::vhost (
     ssl                         => $ssl,
     ssl_cert                    => $ssl_cert,
     ssl_key                     => $ssl_key,
+    ssl_chain                   => $ssl_chain,
     additional_includes         => $ldap_additional_includes,
     wsgi_daemon_process         => $user,
     wsgi_process_group          => $group,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add possibility to configure intermediate certs
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
Intermediate certificates can't be passed to vhost config
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
