### PR TITLE
Drop Python 2, implement Python 3, replace virtualenv with native python 3 implementation, drop EPEL parameter

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,6 +2,7 @@
 .travis.yml:
   secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
   docker_sets:
-    - set: ubuntu1604-64
+    - set: ubuntu1604-64{image=ubuntu:xenial-20191212}
+    - set: ubuntu1804-64
     - set: debian9-64
     - set: debian10-64

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,4 +3,4 @@
   secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
   docker_sets:
     - set: ubuntu1604-64
-    - set: centos7-64
+    - set: centos7-64{image=centos:7.6.1810}

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,3 +3,5 @@
   secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
   docker_sets:
     - set: ubuntu1604-64
+    - set: debian9-64
+    - set: debian10-64

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,4 +3,3 @@
   secure: "Hw0ScFZ+tANSuxXvkQlHOtbnV+9O6FyIxY4e8ZuNiE+4E045olgGjqus+ffo0MoHOHzCPPbThF107yQIXXHCwIy3wzOVIjQ7KQ/yVeamCl4K9A4AFP1Pcr/zMTRdK16zrgxBH+6wDkjSxHGonT8AyUKBrT7AeET+pqxwVHvHCfo="
   docker_sets:
     - set: ubuntu1604-64
-    - set: centos7-64{image=centos:7.6.1810}

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,6 @@ matrix:
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
-    services: docker
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
-    services: docker
-  - rvm: 2.5.3
-    bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,22 @@ matrix:
     bundler_args: --without development release
     env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian9-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian10-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,19 @@ matrix:
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{image=ubuntu:xenial-20191212} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{image=ubuntu:xenial-20191212} BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64 BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release

--- a/files/wsgi.py
+++ b/files/wsgi.py
@@ -1,13 +1,12 @@
+# THIS FILE IS MANAGED BY PUPPET
 from __future__ import absolute_import
 
 import os
 import sys
 
-os.environ['PUPPETBOARD_SETTINGS'] = '<%= @basedir %>/puppetboard/settings.py'
-activate_this = '<%= @basedir %>/virtenv-puppetboard/bin/activate_this.py'
-exec(compile(open(activate_this).read(), activate_this, 'exec'), dict(__file__=activate_this))
-
 me = os.path.dirname(os.path.abspath(__file__))
+os.environ['PUPPETBOARD_SETTINGS'] = os.path.join(me, 'settings.py')
+
 # Add us to the PYTHONPATH/sys.path if we're not on it
 if not me in sys.path:
     sys.path.insert(0, me)

--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -86,7 +86,7 @@ class puppetboard::apache::conf (
 
   file { "${docroot}/wsgi.py":
     ensure  => present,
-    content => template('puppetboard/wsgi.py.erb'),
+    content => file("${module_name}/wsgi.py"),
     owner   => $user,
     group   => $group,
     require => [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,31 @@ class puppetboard::params {
     default: { fail("The ${facts['os']['family']} operating system is not supported with the puppetboard module") }
   }
 
+  case $facts['os']['name'] {
+    'Debian': {
+      $python_version = $facts['os']['release']['major'] ? {
+        '9'  => '3.5',
+        '10' => '3.7',
+        '11' => '3.8',
+      }
+    }
+    'Ubuntu': {
+      $python_version = $facts['os']['release']['major'] ? {
+        '16.04' => '3.5',
+        '18.04' => '3.6',
+        '20.04' => '3.8',
+      }
+    }
+    'CentOS','RedHat': {
+      $python_version = $facts['os']['release']['major'] ? {
+        '7' => '3.6',
+        '8' => '3.8',
+      }
+    }
+    default: {
+      fail("puppet/puppetboard: At the moment only Debian, Ubuntu and CentOS/RedHat are supported, not ${facts['os']['name']} in Version ${facts['os']['release']['full']}")
+    }
+  }
   $manage_selinux = fact('os.selinux.enabled') ? {
     true   => true,
     default => false,
@@ -35,7 +60,7 @@ class puppetboard::params {
   $group = 'puppetboard'
   $basedir = '/srv/puppetboard'
   $git_source = 'https://github.com/voxpupuli/puppetboard'
-  $puppetdb_host = 'localhost'
+  $puppetdb_host = '127.0.0.1'
   $puppetdb_port = 8080
   $puppetdb_ssl_verify = false
   $puppetdb_timeout = 20
@@ -49,12 +74,11 @@ class puppetboard::params {
   $python_loglevel = 'info'
   $reports_count = 10
   $experimental = false
-  $virtualenv = 'python-virtualenv'
-  $virtualenv_version = 'system'
   $listen = 'private'
   $apache_override = 'None'
   $default_environment = 'production'
   $extra_settings = {}
   $enable_ldap_auth = false
   $ldap_require_group = false
+  $virtualenv_dir = "${basedir}/virtenv-puppetboard"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -14,27 +14,6 @@
   "issues_url": "https://github.com/voxpupuli/puppet-puppetboard/issues",
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8"

--- a/metadata.json
+++ b/metadata.json
@@ -26,12 +26,6 @@
         "16.04",
         "18.04"
       ]
-    },
-    {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
     }
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -23,8 +23,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -15,15 +15,8 @@ describe 'puppetboard', type: :class do
       it { is_expected.to contain_file('/srv/puppetboard') }
       it { is_expected.to contain_group('puppetboard') }
       it { is_expected.to contain_user('puppetboard') }
-      it { is_expected.to contain_python__virtualenv('/srv/puppetboard/virtenv-puppetboard') }
+      it { is_expected.to contain_python__pyvenv('/srv/puppetboard/virtenv-puppetboard') }
       it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }
-      context 'with python_use_epel=>false' do
-        let :params do
-          { python_use_epel: false, manage_virtualenv: true }
-        end
-
-        it { is_expected.to contain_class('python').with_use_epel(false) }
-      end
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,5 +3,6 @@ require 'voxpupuli/acceptance/spec_helper_acceptance'
 configure_beaker do |host|
   # Install additional modules for soft deps
   install_module_from_forge_on(host, 'puppetlabs-apache', '>= 2.1.0 < 6.0.0')
+  install_module_from_forge_on(host, 'puppetlabs-puppetdb', '>= 7.6.0 < 8.0.0')
   install_module_from_forge_on(host, 'puppet-epel', '>= 3.0.0 < 4.0.0')
 end


### PR DESCRIPTION
#### Pull Request (PR) description

This PR attempts to fix tests that have been failing and blocking all PR from being merged.

To support python3, we have to introduce a few new variables to support
this creation of a py3 virtualenv, and also to set wsgi python-home [1]
it. Just using activate_this.py didn't work.

In test, we also choose to use a separate virtualenv
`virtenv3-puppetboard` because `virtenv-puppetboard' will be created as
a py2 virtualenv by the other tests.

[1]: https://modwsgi.readthedocs.io/en/develop/user-guides/virtual-environments.html

#### This Pull Request (PR) fixes the following issues
Fixes #287