### PR TITLE
Fix "unresponsive" default value; default to 3 instead of 0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class puppetboard (
   Variant[Boolean, Stdlib::AbsolutePath] $puppetdb_ssl_verify = false,
   Optional[Stdlib::AbsolutePath] $puppetdb_cert               = undef,
   Integer[0] $puppetdb_timeout                                = 20,
-  Integer[0] $unresponsive                                    = 0,
+  Integer[0] $unresponsive                                    = $puppetboard::params::unresponsive,
   Boolean $enable_catalog                                     = false,
   Boolean $enable_query                                       = true,
   Boolean $localise_timestamp                                 = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,7 +70,7 @@ class puppetboard (
   Variant[Boolean, Stdlib::AbsolutePath] $puppetdb_ssl_verify = false,
   Optional[Stdlib::AbsolutePath] $puppetdb_cert               = undef,
   Integer[0] $puppetdb_timeout                                = 20,
-  Integer[0] $unresponsive                                    = $puppetboard::params::unresponsive,
+  Integer[0] $unresponsive                                    = 3,
   Boolean $enable_catalog                                     = false,
   Boolean $enable_query                                       = true,
   Boolean $localise_timestamp                                 = true,


### PR DESCRIPTION
#### Pull Request (PR) description

The 7.0.0 release of the module change the default value to 0 instead of
3 which is set in params.pp.

Restore the previous value.

#### This Pull Request (PR) fixes the following issues

n/a