### PR TITLE
Fix running puppetboard without vhost

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -160,7 +160,7 @@ Data type: `Integer[0]`
 
 number of hours after which a node is considered "unresponsive"
 
-Default value: `0`
+Default value: `3`
 
 ##### `enable_catalog`
 
@@ -476,6 +476,14 @@ LDAP group DN for LDAP group
 
 Default value: ``undef``
 
+##### `virtualenv_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+Set location where virtualenv will be installed
+
+Default value: `$puppetboard::virtualenv_dir`
+
 ### `puppetboard::apache::vhost`
 
 Sets up an apache::vhost to run PuppetBoard, and writes an appropriate wsgi.py from template
@@ -576,7 +584,7 @@ Data type: `String[1]`
 
 Sets the Apache AllowOverride value
 
-Default value: `$puppetboard::apache_override`
+Default value: `$puppetboard::override`
 
 ##### `enable_ldap_auth`
 

--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -13,6 +13,7 @@
 # @param ldap_bind_authoritative Determines if other authentication providers are used when a user can be mapped to a DN but the server cannot bind with the credentials
 # @param ldap_require_group LDAP group to require on login
 # @param ldap_require_group_dn LDAP group DN for LDAP group
+# @param virtualenv_dir Set location where virtualenv will be installed
 #
 # @note Make sure you have purge_configs set to false in your apache class!
 # @note This runs the WSGI application with a WSGIProcessGroup of $user and a WSGIApplicationGroup of %{GLOBAL}.
@@ -31,6 +32,7 @@ class puppetboard::apache::conf (
   Optional[String[1]] $ldap_bind_authoritative = undef,
   Boolean $ldap_require_group                  = $puppetboard::ldap_require_group,
   Optional[String[1]] $ldap_require_group_dn   = undef,
+  Stdlib::Absolutepath $virtualenv_dir         = $puppetboard::virtualenv_dir,
 ) inherits puppetboard {
   $docroot = "${basedir}/puppetboard"
 

--- a/templates/apache/conf.erb
+++ b/templates/apache/conf.erb
@@ -1,4 +1,4 @@
-WSGIDaemonProcess puppetboard user=<%= @user -%> group=<%= @user -%> threads=<%= @threads %> maximum-requests=<%= @max_reqs %>
+WSGIDaemonProcess puppetboard python-home=<%= @virtualenv_dir %> user=<%= @user -%> group=<%= @user -%> threads=<%= @threads %> maximum-requests=<%= @max_reqs %>
 WSGIScriptAlias <%= @wsgi_alias -%> <%= @docroot -%>/wsgi.py
 
 <Directory <%= @docroot -%>>


### PR DESCRIPTION
#### Pull Request (PR) description

Running puppetboard without a vhost was not tested, so the changes that
we made in #302 were just for puppetboard::apache::vhost, and did not
extend to puppetboard::apache::conf

Fix up puppetboard::apache::conf the same way, and add a test