### PR TITLE
Fix python::pyvenv behind proxy.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,13 +151,21 @@ class puppetboard (
     require => Vcsrepo["${basedir}/puppetboard"],
   }
 
+  $pyvenv_proxy_env = $python_proxy ? {
+    undef => [],
+    default => [
+      "HTTP_PROXY=${python_proxy}",
+      "HTTPS_PROXY=${python_proxy}",
+    ]
+  }
   python::pyvenv { $virtualenv_dir:
-    ensure     => present,
-    version    => $python_version,
-    systempkgs => false,
-    owner      => $user,
-    group      => $group,
-    require    => Vcsrepo["${basedir}/puppetboard"],
+    ensure      => present,
+    version     => $python_version,
+    systempkgs  => false,
+    owner       => $user,
+    group       => $group,
+    require     => Vcsrepo["${basedir}/puppetboard"],
+    environment => $pyvenv_proxy_env,
   }
   python::requirements { "${basedir}/puppetboard/requirements.txt":
     virtualenv => $virtualenv_dir,


### PR DESCRIPTION
Proxy settings were not being passed to python::pyvenv meaning that
installation behind a proxy would fail.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Pass proxy settings via environment variables for python::pyvenv.

#### This Pull Request (PR) fixes the following issues

Fixes #315
