### PR TITLE
metadata.json: increase python minimum to 4.1.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 1.12.0 < 6.0.0"
+      "version_requirement": ">= 4.1.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",


### PR DESCRIPTION
In https://github.com/voxpupuli/puppet-puppetboard/commit/e64df5b792ff3a75b7369ddc8609803699f99bd0#diff-c6c3a824d185ff01e063011517a1b13a604dc3d7b63d1c67a30451c10df02bcbR293 this module began using the `manage_virtualenv_package` parameter of the python module. This parameter first appeared in version 4.1.0 of the python
module: https://github.com/voxpupuli/puppet-python/commit/a6b8f4dd6b6faea0b2439d42b2f2686be8037fb9

Fixes #319