### PR TITLE
Fix the way facts are set in the test suite

### DIFF
--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'puppetboard', type: :class do
   on_supported_os.each do |os, facts|
-    let :facts do
-      facts
-    end
-
     context "on #{os}" do
+      let :facts do
+        facts
+      end
+
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('puppetboard') }
       it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }

--- a/spec/classes/vhost_spec.rb
+++ b/spec/classes/vhost_spec.rb
@@ -18,11 +18,11 @@ describe 'puppetboard::apache::vhost' do
     end
 
     on_supported_os.each do |os, facts|
-      let :facts do
-        facts
-      end
-
       context "on  #{os}" do
+        let :facts do
+          facts
+        end
+
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('puppetboard::apache::vhost') }
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/wsgi.py') }


### PR DESCRIPTION
#### Pull Request (PR) description
We must set the facts in the context of a specific operating system,
otherwise all operating systems will share the same facts.

This is currently not a problem because only Debian and Ubuntu are
supported and tested against, and Ubuntu being a Debian derivative both
OS facts are interchangeable, but adding support for more operating
systems trigger errors (e.g. FreeBSD).

#### This Pull Request (PR) fixes the following issues
n/a
