### PR TITLE
Add support for FreeBSD

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,0 +1,7 @@
+---
+puppetboard::apache_confd: "/usr/local/etc/apache24/conf.d"
+puppetboard::apache_service: "apache24"
+puppetboard::install_from: "package"
+puppetboard::package_name: "py38-puppetboard"
+puppetboard::python_version: "3.8"
+puppetboard::settings_file: "/usr/local/etc/puppetboard/settings.py"

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -64,10 +64,6 @@ class puppetboard::apache::vhost (
     content => file("${module_name}/wsgi.py"),
     owner   => $user,
     group   => $group,
-    require => [
-      User[$user],
-      Vcsrepo[$docroot],
-    ],
   }
 
   if $enable_ldap_auth {
@@ -90,6 +86,7 @@ class puppetboard::apache::vhost (
   apache::vhost { $vhost_name:
     port                => $port,
     docroot             => $docroot,
+    manage_docroot      => false,
     ssl                 => $ssl,
     ssl_cert            => $ssl_cert,
     ssl_key             => $ssl_key,
@@ -103,5 +100,6 @@ class puppetboard::apache::vhost (
     notify              => Service[$puppetboard::apache_service],
     *                   => $custom_apache_parameters,
   }
-  File["${basedir}/puppetboard/settings.py"] ~> Service['httpd']
+
+  File[$puppetboard::settings_file] ~> Service[$puppetboard::apache_service]
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class puppetboard (
   if $manage_user {
     user { $user:
       ensure     => present,
-      shell      => '/bin/bash',
+      shell      => '/bin/sh',
       home       => $homedir,
       managehome => true,
       gid        => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # @summary Base class for Puppetboard. Sets up the user and python environment.
 #
+# @param install_from Specify how the package should be installed
 # @param user Puppetboard system user.
 # @param homedir Puppetboard system user's home directory.
 # @param group Puppetboard system group.
@@ -31,8 +32,10 @@
 # @param virtualenv_dir Set location where virtualenv will be installed
 # @param manage_user If true, manage (create) this group. If false do nothing.
 # @param manage_group If true, manage (create) this group. If false do nothing.
+# @param package_name Name of the package to install puppetboard
 # @param manage_selinux If true, manage selinux policies for puppetboard. If false do nothing.
 # @param reports_count This is the number of reports that we want the dashboard to display.
+# @param settings_file Path to puppetboard configuration file
 # @param extra_settings Defaults to an empty hash '{}'. Used to pass in arbitrary key/value
 # @param override Sets the Apache AllowOverride value
 # @param enable_ldap_auth Whether to enable LDAP auth
@@ -58,6 +61,7 @@ class puppetboard (
   Stdlib::Absolutepath $apache_confd,
   String[1] $apache_service,
   Pattern[/^3\.\d$/] $python_version,
+  Enum['package', 'vcsrepo'] $install_from                    = 'vcsrepo',
   Boolean $manage_selinux                                     = pick($facts['os.selinux.enabled'], false),
   String $user                                                = 'puppetboard',
   Optional[Stdlib::Absolutepath] $homedir                     = undef,
@@ -84,12 +88,14 @@ class puppetboard (
   Optional[String] $revision                                  = undef,
   Boolean $manage_user                                        = true,
   Boolean $manage_group                                       = true,
+  Optional[String[1]] $package_name                           = undef,
   Boolean $manage_git                                         = false,
   Boolean $manage_virtualenv                                  = false,
   Stdlib::Absolutepath $virtualenv_dir                        = "${basedir}/virtenv-puppetboard",
   Integer[0] $reports_count                                   = 10,
   String[1] $default_environment                              = 'production',
   Boolean $offline_mode                                       = false,
+  Stdlib::Absolutepath $settings_file                         = "${basedir}/puppetboard/settings.py",
   Hash $extra_settings                                        = {},
   String[1] $override                                         = 'None',
   Boolean $enable_ldap_auth                                   = false,
@@ -115,61 +121,75 @@ class puppetboard (
     }
   }
 
-  file { $basedir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
+  case $install_from {
+    'package': {
+      package { $package_name:
+        ensure => installed,
+      }
+    }
+    'vcsrepo': {
+      file { $basedir:
+        ensure => 'directory',
+        owner  => $user,
+        group  => $group,
+        mode   => '0755',
+      }
+
+      vcsrepo { "${basedir}/puppetboard":
+        ensure   => present,
+        provider => git,
+        owner    => $user,
+        source   => $git_source,
+        revision => $revision,
+        require  => [
+          User[$user],
+          Group[$group],
+        ],
+        before   => [
+          File[$settings_file],
+        ],
+      }
+
+      file { "${basedir}/puppetboard":
+        owner   => $user,
+        recurse => true,
+        require => Vcsrepo["${basedir}/puppetboard"],
+      }
+
+      $pyvenv_proxy_env = $python_proxy ? {
+        undef => [],
+        default => [
+          "HTTP_PROXY=${python_proxy}",
+          "HTTPS_PROXY=${python_proxy}",
+        ]
+      }
+      python::pyvenv { $virtualenv_dir:
+        ensure      => present,
+        version     => $python_version,
+        systempkgs  => false,
+        owner       => $user,
+        group       => $group,
+        require     => Vcsrepo["${basedir}/puppetboard"],
+        environment => $pyvenv_proxy_env,
+      }
+      python::requirements { "${basedir}/puppetboard/requirements.txt":
+        virtualenv => $virtualenv_dir,
+        proxy      => $python_proxy,
+        owner      => $user,
+        group      => $group,
+      }
+    }
+    default: {
+      fail("Unsupported installation method: ${install_from}")
+    }
   }
 
-  vcsrepo { "${basedir}/puppetboard":
-    ensure   => present,
-    provider => git,
-    owner    => $user,
-    source   => $git_source,
-    revision => $revision,
-    require  => [
-      User[$user],
-      Group[$group],
-    ],
-  }
-
-  file { "${basedir}/puppetboard":
-    owner   => $user,
-    recurse => true,
-    require => Vcsrepo["${basedir}/puppetboard"],
-  }
-
-  file { "${basedir}/puppetboard/settings.py":
+  file { $settings_file:
     ensure  => 'file',
     group   => $group,
     mode    => '0644',
     owner   => $user,
     content => template('puppetboard/settings.py.erb'),
-    require => Vcsrepo["${basedir}/puppetboard"],
-  }
-
-  $pyvenv_proxy_env = $python_proxy ? {
-    undef => [],
-    default => [
-      "HTTP_PROXY=${python_proxy}",
-      "HTTPS_PROXY=${python_proxy}",
-    ]
-  }
-  python::pyvenv { $virtualenv_dir:
-    ensure      => present,
-    version     => $python_version,
-    systempkgs  => false,
-    owner       => $user,
-    group       => $group,
-    require     => Vcsrepo["${basedir}/puppetboard"],
-    environment => $pyvenv_proxy_env,
-  }
-  python::requirements { "${basedir}/puppetboard/requirements.txt":
-    virtualenv => $virtualenv_dir,
-    proxy      => $python_proxy,
-    owner      => $user,
-    group      => $group,
   }
 
   if $manage_git and !defined(Package['git']) {

--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,13 @@
       ]
     },
     {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "12",
+        "13"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -9,13 +9,17 @@ describe 'puppetboard', type: :class do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('puppetboard') }
-      it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
-      it { is_expected.to contain_file('/srv/puppetboard/puppetboard') }
-      it { is_expected.to contain_file('/srv/puppetboard') }
       it { is_expected.to contain_group('puppetboard') }
       it { is_expected.to contain_user('puppetboard') }
-      it { is_expected.to contain_python__pyvenv('/srv/puppetboard/virtenv-puppetboard') }
-      it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }
+      if ['FreeBSD'].include?(facts[:os]['family'])
+        it { is_expected.to contain_package('py38-puppetboard') }
+      else
+        it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
+        it { is_expected.to contain_file('/srv/puppetboard/puppetboard') }
+        it { is_expected.to contain_file('/srv/puppetboard') }
+        it { is_expected.to contain_python__pyvenv('/srv/puppetboard/virtenv-puppetboard') }
+        it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }
+      end
     end
   end
 end

--- a/spec/classes/vhost_spec.rb
+++ b/spec/classes/vhost_spec.rb
@@ -18,7 +18,7 @@ describe 'puppetboard::apache::vhost' do
     end
 
     on_supported_os.each do |os, facts|
-      context "on  #{os}" do
+      context "on #{os}" do
         let :facts do
           facts
         end


### PR DESCRIPTION
#### Pull Request (PR) description

This PR add support for FreeBSD.

PuppetBoard is available as a package on FreeBSD, so we can simply ensure this package is installed.

This is currently a WIP, and the pull request was open in order to track CI status and gather early feedback from the community.  When the support of apache is finished, the draft PR status will be removed.

#### This Pull Request (PR) fixes the following issues
n/a

#### Current state: the configuration file management need some more work.

On FreeBSD, we setup `/usr/local/etc/puppetboard/default_settings.py` which is a copy of the `default_settings.py` file already part of puppetboard.  This might have make some sense at some point in the early days of puppetboard, but the default configuration is always loaded so this behavior is now inconsistent because we basically load the configuration twice.  The name is also inconsistent.

I am thinking about adjusting this at multiple levels:
  * [x] https://github.com/voxpupuli/puppetboard/pull/628 — In puppetboard itself: add a `settings.py` "demo"  which only contains comments and pointers to the documentation;
  * [x] https://github.com/freebsd/freebsd-ports/commit/42359e9810bb6bc69d803c6e7bcae256afe95d61 In the FreeBSD port: stop copying `default_settings.py` and install the above file as `/usr/local/etc/puppetboard/settings.py`;
  * [x] Adjust this PR to use that path.