### PR TITLE
Fix dependencies when listen = public

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,6 +172,7 @@ class puppetboard (
     proxy      => $python_proxy,
     owner      => $user,
     group      => $group,
+    require    => Python::Pyvenv[$virtualenv_dir],
   }
 
   if $listen == 'public' {
@@ -181,7 +182,7 @@ class puppetboard (
       match   => ' app.run\(\'([\d\.]+)\'\)',
       require => [
         File["${basedir}/puppetboard"],
-        Python::Virtualenv["${basedir}/virtenv-puppetboard"]
+        Python::Requirements["${basedir}/puppetboard/requirements.txt"],
       ],
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,7 +167,7 @@ class puppetboard (
     require     => Vcsrepo["${basedir}/puppetboard"],
     environment => $pyvenv_proxy_env,
   }
-  python::requirements { "${basedir}/puppetboard/requirements.txt":
+  python::pip { "${basedir}/puppetboard":
     virtualenv => $virtualenv_dir,
     proxy      => $python_proxy,
     owner      => $user,
@@ -182,7 +182,7 @@ class puppetboard (
       match   => ' app.run\(\'([\d\.]+)\'\)',
       require => [
         File["${basedir}/puppetboard"],
-        Python::Requirements["${basedir}/puppetboard/requirements.txt"],
+        Python::Pip["${basedir}/puppetboard"],
       ],
     }
   }


### PR DESCRIPTION
When listen is equals to public
The Virtualenv resource is not created, instead `Python::Requirements` can be used

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
When listen is equals to public this error happens
```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Python::Virtualenv[/srv/puppetboard/virtenv-puppetboard]' in parameter 'require' (file: /etc/puppetlabs/code/environments/PuppetDB/modules/puppetboard/manifests/init.pp, line: 174) on node vpuppetdb
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```

To fix it, the require can be replaced with pyenv resource
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
