### PR TITLE
Allow up-to-date dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,7 +43,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     },
     {
       "name": "puppet/python",


### PR DESCRIPTION
Blocked by:

* https://github.com/voxpupuli/puppet-python/pull/622
* https://github.com/puppetlabs/puppetlabs-puppetdb/pull/335
* A release of https://github.com/puppetlabs/puppetlabs-puppetdb
