### PR TITLE
#338 - Target Python 3.9 for Debian 11

### DIFF
--- a/data/os/Debian.11.yaml
+++ b/data/os/Debian.11.yaml
@@ -1,1 +1,1 @@
-puppetboard::python_version: '3.8'
+puppetboard::python_version: '3.9'

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Update module data to target correct system python for Debian 11.

#### This Pull Request (PR) fixes the following issues
Fixes #338 