### PR TITLE
Support Debian 11

### DIFF
--- a/data/os/Debian.11.yaml
+++ b/data/os/Debian.11.yaml
@@ -1,1 +1,1 @@
-puppetboard::python_version: '3.8'
+puppetboard::python_version: '3.9'

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
Rebase of #346.

- Support Debian 11 in metadata
- Bump Debian python version