### PR TITLE
use vcsrepo "${basedir}/puppetboard" with group "$group"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,6 +139,7 @@ class puppetboard (
         ensure   => present,
         provider => git,
         owner    => $user,
+        group    => $group,
         source   => $git_source,
         revision => $revision,
         require  => [


### PR DESCRIPTION
#### Pull Request (PR) description
the vcsrepo resource which checks out puppetboard uses $group (which it already required in previous versions) instead of the default group (usually root)