### PR TITLE
Clone git repository as $user

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,6 +148,7 @@ class puppetboard (
         before   => [
           File[$settings_file],
         ],
+        notify   => Python::Requirements["${basedir}/puppetboard/requirements.txt"],
       }
 
       $pyvenv_proxy_env = $python_proxy ? {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@ class puppetboard (
       vcsrepo { "${basedir}/puppetboard":
         ensure   => present,
         provider => git,
-        owner    => $user,
+        user     => $user,
         source   => $git_source,
         revision => $revision,
         require  => [
@@ -148,12 +148,6 @@ class puppetboard (
         before   => [
           File[$settings_file],
         ],
-      }
-
-      file { "${basedir}/puppetboard":
-        owner   => $user,
-        recurse => true,
-        require => Vcsrepo["${basedir}/puppetboard"],
       }
 
       $pyvenv_proxy_env = $python_proxy ? {

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -2,7 +2,9 @@
 
 require 'spec_helper_acceptance'
 
-describe 'puppetboard class' do
+require_relative 'support/puppetdb'
+
+describe 'puppetboard class', if: has_puppetdb do
   case fact('os.family')
   when 'RedHat'
     apache_conf_file = '/etc/httpd/conf.d/25-puppetboard.conf'

--- a/spec/acceptance/support/puppetdb.rb
+++ b/spec/acceptance/support/puppetdb.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+def has_puppetdb
+  case host_inventory['facter']['os']['name']
+  when 'Debian'
+    return false if ENV['BEAKER_PUPPET_COLLECTION'] == 'puppet6' && host_inventory['facter']['os']['release']['major'] == '11'
+  end
+
+  true
+end

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -18,7 +18,6 @@ describe 'puppetboard', type: :class do
         it { is_expected.to contain_package('py38-puppetboard') }
       else
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
-        it { is_expected.to contain_file('/srv/puppetboard/puppetboard') }
         it { is_expected.to contain_file('/srv/puppetboard') }
         it { is_expected.to contain_python__pyvenv('/srv/puppetboard/virtenv-puppetboard') }
         it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,8 @@
+if $facts['os']['name'] == 'Ubuntu' {
+  # Needed for facter to fetch facts used by the postgresql module
+  if versioncmp($facts['facterversion'], '4.0.0') <= 0 {
+    package{ 'lsb-release':
+      ensure => present,
+    }
+  }
+}


### PR DESCRIPTION
Instead of cloning as root and using a file resource to change files
ownership to the configured user, directly clone the repository with
this user.

This fix a warning issued by puppet:
Warning: The directory '/srv/puppetboard/puppetboard' contains 1936 entries, which exceeds the default soft limit 1000

Fixes #351
