### PR TITLE
Install from PyPI package and keep up to date by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,8 +13,6 @@
 # @param puppetdb_ssl_verify whether PuppetDB uses SSL or not (true or false), or the path to the puppet CA
 # @param puppetdb_cert path to PuppetMaster/CA signed client SSL cert
 # @param puppetdb_timeout timeout, in seconds, for connecting to PuppetDB
-# @param dev_listen_host host that dev server binds to/listens on
-# @param dev_listen_port port that dev server binds to/listens on
 # @param unresponsive number of hours after which a node is considered "unresponsive"
 # @param enable_catalog Whether to allow the user to browser catalog comparisons.
 # @param enable_query Whether to allow the user to run raw queries against PuppetDB.
@@ -24,7 +22,6 @@
 # @param python_proxy HTTP proxy server to use for pip/virtualenv.
 # @param python_index HTTP index server to use for pip/virtualenv.
 # @param default_environment set the default environment
-# @param experimental Enable experimental features.
 # @param revision Commit, tag, or branch from Puppetboard's Git repo to be used
 # @param version PyPI package version to be installed
 # @param use_pre_releases if version is set to 'latest', then should pre-releases be used too?
@@ -71,8 +68,6 @@ class puppetboard (
   Optional[Variant[String[1], Array[String[1]]]] $groups      = undef,
   Stdlib::AbsolutePath $basedir                               = '/srv/puppetboard',
   String $git_source                                          = 'https://github.com/voxpupuli/puppetboard',
-  String $dev_listen_host                                     = '127.0.0.1',
-  Stdlib::Port $dev_listen_port                               = 5000,
   String $puppetdb_host                                       = '127.0.0.1',
   Stdlib::Port $puppetdb_port                                 = 8080,
   Optional[Stdlib::AbsolutePath] $puppetdb_key                = undef,
@@ -86,7 +81,6 @@ class puppetboard (
   Puppetboard::Syslogpriority $python_loglevel                = 'info',
   Optional[String[1]] $python_proxy                           = undef,
   Optional[String[1]] $python_index                           = undef,
-  Boolean $experimental                                       = false,
   Optional[String] $revision                                  = undef,
   Boolean $manage_user                                        = true,
   Boolean $manage_group                                       = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # @summary Base class for Puppetboard. Sets up the user and python environment.
 #
-# @param install_from Specify how the package should be installed
+# @param install_from Specify how the app should be installed
 # @param user Puppetboard system user.
 # @param homedir Puppetboard system user's home directory.
 # @param group Puppetboard system group.
@@ -141,6 +141,10 @@ class puppetboard (
       }
     }
     'pip': {
+      if $revision {
+        fail("'pip' installation method uses \$version parameter to specify version, not \$revision.")
+      }
+
       file { "${basedir}/puppetboard":
         ensure  => directory,
         recurse => true,
@@ -174,6 +178,10 @@ class puppetboard (
       }
     }
     'vcsrepo': {
+      if $version != 'latest' {
+        fail("'vcsrepo' installation method uses \$revision parameter to specify version, not \$version.")
+      }
+
       notify { 'Not recommended':
         message => "This installation method is recommended mainly for the contributors to voxpupuli/puppetboard.
                     Consider switching to 'pip' if you are not one of them.",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,8 @@
 # @param default_environment set the default environment
 # @param experimental Enable experimental features.
 # @param revision Commit, tag, or branch from Puppetboard's Git repo to be used
+# @param version PyPI package version to be installed
+# @param use_pre_releases if version is set to 'latest', then should pre-releases be used too?
 # @param manage_git If true, require the git package. If false do nothing.
 # @param manage_virtualenv If true, require the virtualenv package. If false do nothing.
 # @param python_version Python version to use in virtualenv.
@@ -61,7 +63,7 @@ class puppetboard (
   Stdlib::Absolutepath $apache_confd,
   String[1] $apache_service,
   Pattern[/^3\.\d$/] $python_version,
-  Enum['package', 'vcsrepo'] $install_from                    = 'vcsrepo',
+  Enum['package', 'pip', 'vcsrepo'] $install_from             = 'pip',
   Boolean $manage_selinux                                     = pick($facts['os.selinux.enabled'], false),
   String $user                                                = 'puppetboard',
   Optional[Stdlib::Absolutepath] $homedir                     = undef,
@@ -100,6 +102,8 @@ class puppetboard (
   String[1] $override                                         = 'None',
   Boolean $enable_ldap_auth                                   = false,
   Boolean $ldap_require_group                                 = false,
+  Variant[Enum['latest'], String[1]] $version                 = 'latest',
+  Boolean $use_pre_releases                                   = false,
 ) {
   if $manage_group {
     group { $group:
@@ -121,18 +125,64 @@ class puppetboard (
     }
   }
 
+  $pyvenv_proxy_env = $python_proxy ? {
+    undef   => [],
+    default => [
+      "HTTP_PROXY=${python_proxy}",
+      "HTTPS_PROXY=${python_proxy}",
+    ]
+  }
+
+  file { $basedir:
+    ensure => 'directory',
+    owner  => $user,
+    group  => $group,
+    mode   => '0755',
+  }
+
   case $install_from {
     'package': {
       package { $package_name:
         ensure => installed,
       }
     }
+    'pip': {
+      file { "${basedir}/puppetboard":
+        ensure  => directory,
+        recurse => true,
+        force   => true,
+        purge   => true, # such cleanup is needed in case of a switch from install_from=vcsrepo to install_from=pip
+      }
+
+      python::pyvenv { $virtualenv_dir:
+        ensure      => present,
+        version     => $python_version,
+        systempkgs  => false,
+        owner       => $user,
+        group       => $group,
+        require     => File[$basedir],
+        environment => $pyvenv_proxy_env,
+      }
+
+      $install_args = $use_pre_releases ? {
+        true    => '--pre',
+        default => undef,
+      }
+
+      python::pip { 'puppetboard':
+        ensure       => $version,
+        virtualenv   => $virtualenv_dir,
+        proxy        => $python_proxy,
+        owner        => $user,
+        group        => $group,
+        require      => Python::Pyvenv[$virtualenv_dir],
+        install_args => $install_args,
+      }
+    }
     'vcsrepo': {
-      file { $basedir:
-        ensure => 'directory',
-        owner  => $user,
-        group  => $group,
-        mode   => '0755',
+      notify { 'Not recommended':
+        message => "This installation method is recommended mainly for the contributors to voxpupuli/puppetboard.
+                    Consider switching to 'pip' if you are not one of them.",
       }
 
       vcsrepo { "${basedir}/puppetboard":
@@ -151,13 +201,6 @@ class puppetboard (
         notify   => Python::Requirements["${basedir}/puppetboard/requirements.txt"],
       }
 
-      $pyvenv_proxy_env = $python_proxy ? {
-        undef => [],
-        default => [
-          "HTTP_PROXY=${python_proxy}",
-          "HTTPS_PROXY=${python_proxy}",
-        ]
-      }
       python::pyvenv { $virtualenv_dir:
         ensure      => present,
         version     => $python_version,
@@ -167,6 +210,7 @@ class puppetboard (
         require     => Vcsrepo["${basedir}/puppetboard"],
         environment => $pyvenv_proxy_env,
       }
+
       python::requirements { "${basedir}/puppetboard/requirements.txt":
         virtualenv => $virtualenv_dir,
         proxy      => $python_proxy,
@@ -202,15 +246,15 @@ class puppetboard (
   }
 
   if $manage_selinux {
-    selboolean { 'httpd_can_network_relay' :
+    selboolean { 'httpd_can_network_relay':
       persistent => true,
       value      => 'on',
     }
-    selboolean { 'httpd_can_network_connect' :
+    selboolean { 'httpd_can_network_connect':
       persistent => true,
       value      => 'on',
     }
-    selboolean { 'httpd_can_network_connect_db' :
+    selboolean { 'httpd_can_network_connect_db':
       persistent => true,
       value      => 'on',
     }

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -20,7 +20,7 @@ describe 'puppetboard', type: :class do
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
         it { is_expected.to contain_file('/srv/puppetboard') }
         it { is_expected.to contain_python__pyvenv('/srv/puppetboard/virtenv-puppetboard') }
-        it { is_expected.to contain_vcsrepo('/srv/puppetboard/puppetboard') }
+        it { is_expected.to contain_python__pip('puppetboard') }
       end
     end
   end

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -1,9 +1,3 @@
-<% if @dev_listen_host -%>
-DEV_LISTEN_HOST = '<%= @dev_listen_host %>'
-<% end -%>
-<% if @dev_listen_port -%>
-DEV_LISTEN_PORT = <%= @dev_listen_port %>
-<% end -%>
 <% if @python_loglevel -%>
 LOGLEVEL = '<%= @python_loglevel-%>'
 <% end -%>
@@ -51,11 +45,6 @@ LOCALISE_TIMESTAMP = False
 OFFLINE_MODE = True
 <% else -%>
 OFFLINE_MODE = False
-<% end -%>
-<% if @experimental -%>
-PUPPETDB_EXPERIMENTAL = True
-<% else -%>
-PUPPETDB_EXPERIMENTAL = False
 <% end -%>
 <% if @default_environment -%>
 DEFAULT_ENVIRONMENT = '<%= @default_environment %>'


### PR DESCRIPTION
#### Pull Request (PR) description

Puppetboard developers follow semver, use pre-releses and put a lot of effort into making the PyPI (and Docker) the best way to install the app.

vcsrepo installation method should be used only by the contributors (as: developers and testers of non-releases).

#### This Pull Request (PR) fixes the following issues

* The current default install method installs a non-release from a commit that is at the top of the main branch in voxpupuli/puppetboard and does not update it unless you provide a specific different revision. I would argue that this is not what a regular user would want. I think that a regular user wants to either pin a specific release OR keep puppetboard up to date from the final (stable) releases OR maybe keep up to date from the pre-releases.
* #85