### PR TITLE
Sync FreeBSD default Python version with upstream

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -2,6 +2,6 @@
 puppetboard::apache_confd: "/usr/local/etc/apache24/conf.d"
 puppetboard::apache_service: "apache24"
 puppetboard::install_from: "package"
-puppetboard::package_name: "py38-puppetboard"
-puppetboard::python_version: "3.8"
+puppetboard::package_name: "py39-puppetboard"
+puppetboard::python_version: "3.9"
 puppetboard::settings_file: "/usr/local/etc/puppetboard/settings.py"

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -15,7 +15,7 @@ describe 'puppetboard', type: :class do
       it { is_expected.to contain_user('puppetboard') }
 
       if ['FreeBSD'].include?(facts[:os]['family'])
-        it { is_expected.to contain_package('py38-puppetboard') }
+        it { is_expected.to contain_package('py39-puppetboard') }
       else
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
         it { is_expected.to contain_file('/srv/puppetboard') }


### PR DESCRIPTION
FreeBSD now ships Python 3.9 as the default python version and Python
packages target this version.

Sync with these new defaults so that the module works out-of-the box on
FreeBSD.
