### PR TITLE
puppet/python: Require 6.3 or newer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -245,6 +245,7 @@ class puppetboard (
     class { 'python':
       version => $python_version,
       dev     => 'present',
+      venv    => 'present',
     }
     Class['python'] -> Class['puppetboard']
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,11 +127,13 @@ class puppetboard (
     ]
   }
 
-  file { $basedir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
+  if $install_from in ['pip', 'vcsrepo'] {
+    file { $basedir:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+      mode   => '0755',
+    }
   }
 
   case $install_from {

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.3.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -16,6 +16,7 @@ describe 'puppetboard', type: :class do
 
       if ['FreeBSD'].include?(facts[:os]['family'])
         it { is_expected.to contain_package('py39-puppetboard') }
+        it { is_expected.not_to contain_file('/srv/puppetboard') }
       else
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
         it { is_expected.to contain_file('/srv/puppetboard') }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,5 +6,5 @@ configure_beaker do |host|
   # Install additional modules for soft deps
   install_module_from_forge_on(host, 'puppetlabs-apache', '>= 2.1.0 < 7.0.0')
   install_module_from_forge_on(host, 'puppetlabs-puppetdb', '>= 7.6.0 < 8.0.0')
-  install_module_from_forge_on(host, 'puppet-epel', '>= 3.0.0 < 4.0.0')
+  install_module_from_forge_on(host, 'puppet-epel', '>= 3.0.0 < 5.0.0')
 end


### PR DESCRIPTION
The latest version of the Python module require the use of new parameters.  We run CI (and support) only the latest version of modules, so update this one to match the requirements of recent puppet-python usage.

This PR include:

* #368 