### PR TITLE
Do not manage $basedir when installing from packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,11 +127,13 @@ class puppetboard (
     ]
   }
 
-  file { $basedir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-    mode   => '0755',
+  if $install_from in ['pip', 'vcsrepo'] {
+    file { $basedir:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+      mode   => '0755',
+    }
   }
 
   case $install_from {

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -16,6 +16,7 @@ describe 'puppetboard', type: :class do
 
       if ['FreeBSD'].include?(facts[:os]['family'])
         it { is_expected.to contain_package('py39-puppetboard') }
+        it { is_expected.not_to contain_file('/srv/puppetboard') }
       else
         it { is_expected.to contain_file('/srv/puppetboard/puppetboard/settings.py') }
         it { is_expected.to contain_file('/srv/puppetboard') }


### PR DESCRIPTION
The $basedir directory is the root directory where pip/git fetch and
store all puppetboard data when installing with these tools, but is not
used when installing using system packages.

On FreeBSD, we default to install using packages, and the `/srv`
directory does not exist leading to catalog application falures by
default.

Since this directory is not used in such a case, do not manage it.
