### PR TITLE
Support wsgi on python 3.8, 3.9, 3.11 and 3.12 on rhel8

### DIFF
--- a/data/os/RedHat.8.yaml
+++ b/data/os/RedHat.8.yaml
@@ -1,1 +1,1 @@
-puppetboard::python_version: '3.8'
+puppetboard::python_version: '3.9'

--- a/manifests/apache/conf.pp
+++ b/manifests/apache/conf.pp
@@ -16,7 +16,7 @@
 # @param ldap_require_user if set, list of uids for Require ldap-user directive
 # @param ldap_require_dn if set, dn to be matched by Require ldap-dn directive
 # @param ldap_require_attribute if set, attributes of LDAP users for Require ldap-attribute directive
-# @param ldap_require_filter if set, LDAP search filter for Require ldap-filter directive 
+# @param ldap_require_filter if set, LDAP search filter for Require ldap-filter directive
 # @param virtualenv_dir Set location where virtualenv will be installed
 #
 # @note Make sure you have purge_configs set to false in your apache class!
@@ -46,6 +46,20 @@ class puppetboard::apache::conf (
     'Debian' => {
       package_name => 'libapache2-mod-wsgi-py3',
       mod_path     => '/usr/lib/apache2/modules/mod_wsgi.so',
+    },
+    'RedHat' => $facts['os']['release']['major'] ? {
+      '8'     => {
+        package_name => $puppetboard::python_version ? {
+          '3.6'  => 'python3-mod_wsgi',
+          '3.8'  => 'python38-mod_wsgi',
+          '3.9'  => 'python39-mod_wsgi',
+          '3.11' => 'python3.11-mod_wsgi',
+          '3.12' => 'python3.12-mod_wsgi',
+          default => fail('python version not supported'),
+        },
+        mod_path     => 'modules/mod_wsgi_python3.so',
+      },
+      default => {},
     },
     default  => {},
   }

--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -23,7 +23,7 @@
 # @param ldap_require_user if set, list of uids for Require ldap-user directive
 # @param ldap_require_dn if set, dn to be matched by Require ldap-dn directive
 # @param ldap_require_attribute if set, attributes of LDAP users for Require ldap-attribute directive
-# @param ldap_require_filter if set, LDAP search filter for Require ldap-filter directive 
+# @param ldap_require_filter if set, LDAP search filter for Require ldap-filter directive
 # @param virtualenv_dir Set location where virtualenv will be installed
 # @param custom_apache_parameters A hash passed to the `apache::vhost` for custom settings
 class puppetboard::apache::vhost (
@@ -58,6 +58,20 @@ class puppetboard::apache::vhost (
     'Debian' => {
       package_name => 'libapache2-mod-wsgi-py3',
       mod_path     => '/usr/lib/apache2/modules/mod_wsgi.so',
+    },
+    'RedHat' => $facts['os']['release']['major'] ? {
+      '8'     => {
+        package_name => $puppetboard::python_version ? {
+          '3.6'  => 'python3-mod_wsgi',
+          '3.8'  => 'python38-mod_wsgi',
+          '3.9'  => 'python39-mod_wsgi',
+          '3.11' => 'python3.11-mod_wsgi',
+          '3.12' => 'python3.12-mod_wsgi',
+          default => fail('python version not supported'),
+        },
+        mod_path     => 'modules/mod_wsgi_python3.so',
+      },
+      default => {},
     },
     default  => {},
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -266,8 +266,19 @@ class puppetboard (
   }
 
   if $manage_virtualenv {
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '8') == 0 {
+      $_package_version = $python_version ? {
+        '3.6'  => '36',
+        '3.8'  => '38',
+        '3.9'  => '39',
+        '3.11' => 'python3.11',
+        '3.12' => 'python3.12',
+      }
+    } else {
+      $_package_version = $python_version
+    }
     class { 'python':
-      version => $python_version,
+      version => $_package_version,
       dev     => 'present',
       venv    => 'present',
     }

--- a/metadata.json
+++ b/metadata.json
@@ -16,6 +16,7 @@
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
+        "8",
         "9"
       ]
     },
@@ -42,6 +43,7 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
+        "8",
         "9"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,7 @@
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
+        "8",
         "9"
       ]
     },

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -93,7 +93,6 @@ describe 'puppetboard class', if: has_puppetdb do
       pp = <<-EOS
       # Configure Apache on this server
       class { 'apache': }
-      class { 'apache::mod::wsgi': }
       class { 'puppetboard':
         manage_virtualenv => true,
         manage_git => true,
@@ -110,6 +109,8 @@ describe 'puppetboard class', if: has_puppetdb do
         disable_ssl => true,
         manage_firewall => false,
       }
+
+      class { 'puppetboard::apache::conf': }
       EOS
 
       # Run it twice and test for idempotency

--- a/spec/classes/apache/vhost_spec.rb
+++ b/spec/classes/apache/vhost_spec.rb
@@ -46,6 +46,46 @@ describe 'puppetboard::apache::vhost' do
             'ensure' => 'file'
           )
         end
+
+        if ['RedHat'].include?(facts[:os]['family']) && facts[:os]['release']['major'] == '8'
+          ['3.6', '3.8', '3.9'].each do |python_version|
+            context "with python_versions #{python_version}" do
+              let(:pre_condition) do
+                [
+                  "class { 'puppetboard':
+                    python_version => \"#{python_version}\",
+                    secret_key     => 'this_should_be_a_long_secret_string',
+                  }"
+                ]
+              end
+
+              case python_version
+              when '3.6'
+                package_name = 'python3-mod_wsgi'
+              when '3.8'
+                package_name = 'python38-mod_wsgi'
+              when '3.9'
+                package_name = 'python39-mod_wsgi'
+              end
+
+              it { is_expected.to contain_class('apache::mod::wsgi').with(package_name: package_name) }
+            end
+          end
+
+          context 'with unsupported python_versions' do
+            let(:pre_condition) do
+              [
+                "class { 'puppetboard':
+                  python_version => '3.7',
+                  secret_key     => 'this_should_be_a_long_secret_string',
+                }
+                "
+              ]
+            end
+
+            it { is_expected.to raise_error(Puppet::Error, %r{python version not supported}) }
+          end
+        end
       end
     end
   end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -6,3 +6,13 @@ if $facts['os']['name'] == 'Ubuntu' {
     }
   }
 }
+
+if $facts['os']['family'] == 'RedHat' {
+  if versioncmp($facts['os']['release']['major'], '8') >= 0 {
+    package { 'disable-builtin-dnf-postgresql-module':
+      ensure   => 'disabled',
+      name     => 'postgresql',
+      provider => 'dnfmodule',
+    }
+  }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
As inspired by issue mentioned, this fix the install of wsgi for python 3.8 and 3.9 on rhel.
There is no need to set to specific `mod_path` as the packages provides the file in `httpd/modules`

```bash
yum provides /usr/lib64/httpd/modules/mod_wsgi_python3.so
python3-mod_wsgi-4.6.4-4.el8.x86_64 : A WSGI interface for Python web applications in Apache
Repo        : appstream
Matched from:
Filename    : /usr/lib64/httpd/modules/mod_wsgi_python3.so

python38-mod_wsgi-4.6.8-3.module+el8.4.0+570+c2eaf144.x86_64 : A WSGI interface for Python web applications in Apache
Repo        : appstream
Matched from:
Filename    : /usr/lib64/httpd/modules/mod_wsgi_python3.so

python39-mod_wsgi-4.7.1-4.module+el8.4.0+574+843c4898.x86_64 : A WSGI interface for Python web applications in Apache
Repo        : appstream
Matched from:
Filename    : /usr/lib64/httpd/modules/mod_wsgi_python3.so
```

I’m not a very confident test writer, but I did my best to test the changes I made.  Please suggest what could be done better if you think it is required.

EDIT: as of now, following versions are supported:
- 5.x: Python 3.8-3.11
- 6.x: Python 3.9-3.13
I’ve added versions supported on EL8

#### This Pull Request (PR) fixes the following issues
Fixes #369
Fixes #373
