### PR TITLE
Allow configuring SECRET_KEY easier

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -83,6 +83,7 @@ The following parameters are available in the `puppetboard` class:
 * [`ldap_require_group`](#-puppetboard--ldap_require_group)
 * [`apache_confd`](#-puppetboard--apache_confd)
 * [`apache_service`](#-puppetboard--apache_service)
+* [`secret_key`](#-puppetboard--secret_key)
 
 ##### <a name="-puppetboard--install_from"></a>`install_from`
 
@@ -413,6 +414,14 @@ path to the apache2 vhost directory
 Data type: `String[1]`
 
 name of the apache2 service
+
+##### <a name="-puppetboard--secret_key"></a>`secret_key`
+
+Data type: `Optional[String[1]]`
+
+used for CSRF prevention and more. It should be a long, secret string, the same for all instances of the app. Required since Puppetboard 5.0.0.
+
+Default value: `undef`
 
 ### <a name="puppetboard--apache--conf"></a>`puppetboard::apache::conf`
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -26,6 +26,7 @@ describe 'puppetboard class', if: has_puppetdb do
         manage_virtualenv => true,
         manage_git        => true,
         require           => Class['puppetdb'],
+        secret_key        => 'this_should_be_a_long_secret_string',
       }
 
       # Configure Apache to allow access to localhost/puppetboard
@@ -64,6 +65,7 @@ describe 'puppetboard class', if: has_puppetdb do
         manage_virtualenv => true,
         manage_git        => true,
         require           => Class['puppetdb'],
+        secret_key        => 'this_should_be_a_long_secret_string',
       }
 
       # Access Puppetboard through pboard.example.com
@@ -101,6 +103,7 @@ describe 'puppetboard class', if: has_puppetdb do
         puppetdb_ssl_verify => true,
         puppetdb_cert => '/var/lib/puppet/ssl/certs/test.networkninjas.net.pem',
         require => Class['puppetdb'],
+        secret_key => 'this_should_be_a_long_secret_string',
       }
       # Configure PuppetDB
       class { 'puppetdb':
@@ -135,6 +138,7 @@ describe 'puppetboard class', if: has_puppetdb do
         puppetdb_ssl_verify => true,
         puppetdb_cert => "/var/lib/puppet/ssl/certs/test.networkninjas.net.pem",
         require => Class['puppetdb'],
+        secret_key => 'this_should_be_a_long_secret_string',
       }
       class { 'puppetboard::apache::conf':
         enable_ldap_auth => true,
@@ -181,6 +185,7 @@ describe 'puppetboard class', if: has_puppetdb do
         puppetdb_ssl_verify => true,
         puppetdb_cert => "/var/lib/puppet/ssl/certs/test.networkninjas.net.pem",
         require => Class['puppetdb'],
+        secret_key => 'this_should_be_a_long_secret_string',
       }
       class { 'puppetboard::apache::conf':
         enable_ldap_auth => true,

--- a/spec/classes/apache/conf_spec.rb
+++ b/spec/classes/apache/conf_spec.rb
@@ -10,7 +10,9 @@ describe 'puppetboard::apache::conf' do
     end
     let(:pre_condition) do
       [
-        'class { "puppetboard": }'
+        'class { "puppetboard":
+           secret_key => "this_should_be_a_long_secret_string",
+         }'
       ]
     end
 

--- a/spec/classes/apache/vhost_spec.rb
+++ b/spec/classes/apache/vhost_spec.rb
@@ -17,7 +17,9 @@ describe 'puppetboard::apache::vhost' do
           default_vhost => false,
           default_mods  => false,
         }',
-        'class { "puppetboard": }'
+        'class { "puppetboard":
+           secret_key => "this_should_be_a_long_secret_string",
+         }'
       ]
     end
 

--- a/spec/classes/puppetboard_spec.rb
+++ b/spec/classes/puppetboard_spec.rb
@@ -9,6 +9,9 @@ describe 'puppetboard', type: :class do
         facts
       end
 
+      # With version == 'latest' $secret_key is de facto required
+      let(:params) { { 'secret_key' => 'this_should_be_a_long_secret_string', } }
+
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('puppetboard') }
       it { is_expected.to contain_group('puppetboard') }

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -52,6 +52,9 @@ DEFAULT_ENVIRONMENT = '<%= @default_environment %>'
 <% if @reports_count -%>
 REPORTS_COUNT = <%= @reports_count %>
 <% end -%>
+<% if @secret_key -%>
+SECRET_KEY = '<%= @secret_key %>'
+<% end -%>
 <% @extra_settings.keys.sort.each do |key| -%>
 <%= key %> = <%= @extra_settings[key] %>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

as it's required since Puppetboard 5.0.0 release
and provide a helpful warning that it should be
set if you still use Puppetboard < 5.0.0.

#### This Pull Request (PR) fixes the following issues

Releated to https://github.com/voxpupuli/puppetboard/issues/721.