### PR TITLE
Add graph_facts variable to enable graphing (pie/bar) of Puppet facts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -83,6 +83,7 @@ The following parameters are available in the `puppetboard` class:
 * [`ldap_require_group`](#ldap_require_group)
 * [`apache_confd`](#apache_confd)
 * [`apache_service`](#apache_service)
+* [`graph_facts'](#graph_facts)
 
 ##### <a name="install_from"></a>`install_from`
 
@@ -413,6 +414,12 @@ path to the apache2 vhost directory
 Data type: `String[1]`
 
 name of the apache2 service
+
+##### <a name="graph_facts"></a>`graph_facts`
+
+Data type: `Optional[Variant[String[1], Array[String[1]]]]`
+
+An array of the puppet facts to graph.  See ''https://github.com/voxpupuli/puppetboard''
 
 ### <a name="puppetboardapacheconf"></a>`puppetboard::apache::conf`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 # @param homedir Puppetboard system user's home directory.
 # @param group Puppetboard system group.
 # @param groups additional groups for the user that runs puppetboard
+# @param graph_facts Array of puppet facts to graph (pie/bar chart).
 # @param basedir Base directory where to build puppetboard vcsrepo and python virtualenv.
 # @param git_source Location of upstream Puppetboard GIT repository
 # @param puppetdb_host PuppetDB Host
@@ -67,6 +68,7 @@ class puppetboard (
   Optional[Stdlib::Absolutepath] $homedir                     = undef,
   String $group                                               = 'puppetboard',
   Optional[Variant[String[1], Array[String[1]]]] $groups      = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $graph_facts = undef,
   Stdlib::AbsolutePath $basedir                               = '/srv/puppetboard',
   String $git_source                                          = 'https://github.com/voxpupuli/puppetboard',
   String $dev_listen_host                                     = '127.0.0.1',

--- a/templates/settings.py.erb
+++ b/templates/settings.py.erb
@@ -63,6 +63,9 @@ DEFAULT_ENVIRONMENT = '<%= @default_environment %>'
 <% if @reports_count -%>
 REPORTS_COUNT = <%= @reports_count %>
 <% end -%>
+<% if @graph_facts -%>
+GRAPH_FACTS = '<%= @graph_facts.sort.uniq.join(',') %>'
+<% end -%>
 <% @extra_settings.keys.sort.each do |key| -%>
 <%= key %> = <%= @extra_settings[key] %>
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Adds the graph_facts array/variable to enable the creating of a pie/bar chart of the desired facts.

-->

The [extra_settings](https://github.com/voxpupuli/puppet-puppetboard/blob/master/REFERENCE.md#extra_settings) is somewhat cumbersome to use for GRAPH_FACTS in the settings.py file because it necessitates escaping the single quote character around the facts to be graphed.  This PR adds the graph_facts variable as an array, sorts and unique-ifies the array and wraps the result in a set of single quotes:

`GRAPH_FACTS = 'kernel,operatingsystem,operatingsystemmajrelease'`