### PR TITLE
allow python_version > 3.9

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -310,7 +310,7 @@ Default value: `false`
 
 ##### <a name="-puppetboard--python_version"></a>`python_version`
 
-Data type: `Pattern[/^3\.\d$/]`
+Data type: `Pattern[/^3\.\d+$/]`
 
 Python version to use in virtualenv.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@
 class puppetboard (
   Stdlib::Absolutepath $apache_confd,
   String[1] $apache_service,
-  Pattern[/^3\.\d$/] $python_version,
+  Pattern[/^3\.\d+$/] $python_version,
   Enum['package', 'pip', 'vcsrepo'] $install_from             = 'pip',
   Boolean $manage_selinux                                     = pick($facts['os.selinux.enabled'], false),
   String $user                                                = 'puppetboard',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Allow python_version to have a two digit minor version as in debian bookworm, which ships with 3.11 for example 

