### PR TITLE
On/off switch and config hash parameter for apache::mod::wsgi

### DIFF
--- a/manifests/apache/vhost.pp
+++ b/manifests/apache/vhost.pp
@@ -22,6 +22,8 @@
 # @param ldap_require_group_dn LDAP group DN for LDAP group
 # @param virtualenv_dir Set location where virtualenv will be installed
 # @param custom_apache_parameters A hash passed to the `apache::vhost` for custom settings
+# @param manage_mod_wsgi A parameter to switch off the use of `apache::mod::wsgi`
+# @param custom_mod_wsgi_parameters A hash passed to `apache::mod::wsgi`
 class puppetboard::apache::vhost (
   String[1] $vhost_name,
   Stdlib::Unixpath $wsgi_alias                 = '/',
@@ -45,16 +47,20 @@ class puppetboard::apache::vhost (
   Optional[String[1]] $ldap_require_group_dn   = undef,
   Stdlib::Absolutepath $virtualenv_dir         = $puppetboard::virtualenv_dir,
   Hash $custom_apache_parameters               = {},
+  Boolean $manage_mod_wsgi                     = true,
+  Hash $custom_mod_wsgi_parameters             = {},
 ) {
-  $wsgi = $facts['os']['family'] ? {
-    'Debian' => {
-      package_name => 'libapache2-mod-wsgi-py3',
-      mod_path     => '/usr/lib/apache2/modules/mod_wsgi.so',
-    },
-    default  => {},
-  }
-  class { 'apache::mod::wsgi':
-    * => $wsgi,
+  if $manage_mod_wsgi {
+    $wsgi = $facts['os']['family'] ? {
+      'Debian' => {
+        package_name => 'libapache2-mod-wsgi-py3',
+        mod_path     => '/usr/lib/apache2/modules/mod_wsgi.so',
+      },
+      default  => $custom_mod_wsgi_parameters,
+    }
+    class { 'apache::mod::wsgi':
+      * => $wsgi,
+    }
   }
 
   $docroot = "${basedir}/puppetboard"


### PR DESCRIPTION
#### Pull Request (PR) description
We are running Puppetboard under CentOS 7 and were experiencing the Python 3.6 / WSGI troubles described in the README. As part of the solution we needed a way to either switch off the management of apache::mod::wsgi by puppetboard::apache::vhost or be able to pass custom configuration settings to make Apache load a different module, linked to Python 3.
This PR adds both functions, not just for CentOS 7 as other people might be interested in using other ways to set up mod_wsgi.

#### This Pull Request (PR) fixes the following issues
n/a