### PR TITLE
Allow python 3.10 version to pass regex

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 class puppetboard (
   Stdlib::Absolutepath $apache_confd,
   String[1] $apache_service,
-  Pattern[/^3\.\d+$/] $python_version,
+  Pattern[/^3\.\d{1,2}$/] $python_version,
   Enum['package', 'pip', 'vcsrepo'] $install_from             = 'pip',
   Boolean $manage_selinux                                     = pick($facts['os.selinux.enabled'], false),
   String $user                                                = 'puppetboard',


### PR DESCRIPTION
#### Pull Request (PR) description
Current regex test fails for "3.10", which is the current version on ubuntu 22.04

#### This Pull Request (PR) fixes the following issues

This fixes a failure on Puppet 8.2 in Ubuntu 22.04:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Puppetboard]: parameter 'python_version' expects a match for Pattern[/^3\.\d$/], got '3.10' (file: /etc/puppetlabs/code/environments/staging/site/profile/manifests/puppet/dashboard.pp, line: 19, column: 3) on node puppetdb.staging
```