### PR TITLE
Use Python::Version as type for puppetboard::python_version

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -311,7 +311,7 @@ Default value: `false`
 
 ##### <a name="-puppetboard--python_version"></a>`python_version`
 
-Data type: `Pattern[/^3\.\d{1,2}$|^3\.\d{1,2}\.\d{1,2}$/]`
+Data type: `Python::Version`
 
 Python version to use in virtualenv.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 class puppetboard (
   Stdlib::Absolutepath $apache_confd,
   String[1] $apache_service,
-  Pattern[/^3\.\d{1,2}$|^3\.\d{1,2}\.\d{1,2}$/] $python_version,
+  Python::Version $python_version,
   Enum['package', 'pip', 'vcsrepo'] $install_from             = 'pip',
   Boolean $manage_selinux                                     = pick($facts['os.selinux.enabled'], false),
   String $user                                                = 'puppetboard',


### PR DESCRIPTION
#### Pull Request (PR) description
In RHEL/Rocky 9 the system version of python (`python3` package name) is Python 3.9 version. Trying to use `3.9` for `puppetboard::python_version` yields an error that it can't find that package. Also available is python 3.11 with a package name of `python-3.11`. Because of the existing regexes in both this module and the python module, i wasn't able to come up with a value for `puppetboard::python_version` that would allow me to execute with either of those.

Instead this PR simply utilizes the `Python::Version` type, because that is what the python module uses as its regex verification. Now, we're consistent with what that module uses since it's the actual version spec that matters since we ultimately pass `puppetboard::python_version` down into the python module anyways.
