### PR TITLE
puppet/python: Allow 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 6.3.0 < 7.0.0"
+      "version_requirement": ">= 6.3.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
other modules or control-repos requiring stdlib >= 9 fail to resolve because puppet-python < 7 limits to 8.x.