### PR TITLE
Drop EOL Ubuntu 18.04 support

### DIFF
--- a/data/os/Debian.9.yaml
+++ b/data/os/Debian.9.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.5'

--- a/data/os/Ubuntu.16.04.yaml
+++ b/data/os/Ubuntu.16.04.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.5'

--- a/data/os/Ubuntu.18.04.yaml
+++ b/data/os/Ubuntu.18.04.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.6'

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]


### PR DESCRIPTION
Ubuntu 18.04 tests are failing, so we should drop support for it.