### PR TITLE
Add EL 9 support

### DIFF
--- a/data/os/CentOS.7.yaml
+++ b/data/os/CentOS.7.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.6'

--- a/data/os/CentOS.8.yaml
+++ b/data/os/CentOS.8.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.8'

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,2 +1,0 @@
-puppetboard::apache_confd: '/etc/apache2/conf.d'
-puppetboard::apache_service: 'apache2'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,6 +5,10 @@ defaults:
   data_hash: 'yaml_data'
 hierarchy:
   - name: 'Distribution name and major version'
-    path: "os/%{facts.os.name}.%{facts.os.release.major}.yaml"
+    paths:
+      - "os/%{facts.os.name}.%{facts.os.release.major}.yaml"
+      - "os/%{facts.os.family}.%{facts.os.release.major}.yaml"
   - name: 'Distribution family'
-    path: "os/%{facts.os.family}.yaml"
+    paths:
+      - "os/%{facts.os.name}.yaml"
+      - "os/%{facts.os.family}.yaml"

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,18 @@
   "issues_url": "https://github.com/voxpupuli/puppet-puppetboard/issues",
   "operatingsystem_support": [
     {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10",
@@ -25,6 +37,18 @@
       "operatingsystemrelease": [
         "12",
         "13"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "9"
       ]
     },
     {


### PR DESCRIPTION
- delete Suse hiera data. Suse support was dropped from `metadata.json` in #292 commit 77ea67b22f2ef24920ec56f01e2658770a0a3b9d due to lack of working tests.
- `metadata.json`: Add EL 9 support
- Includes #388