### PR TITLE
Fix formatting of puppetboard class example in reference.md .

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -18,6 +18,7 @@
 
 ### <a name="puppetboard"></a>`puppetboard`
 
+```
 class { 'puppetboard':
    user  => 'pboard',
    group => 'pboard',
@@ -28,6 +29,7 @@ class { 'puppetboard':
    group => 'pboard',
    basedir => '/www/puppetboard'
  }
+```
 
 #### Examples
 


### PR DESCRIPTION
The class [ 'puppetboard': ..} example in the REFERENCE.md displayed as a single line.  This change formats the example so that it's easier to read.