### PR TITLE
.fixtures.yml: Remove puppet version constraint

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,4 @@
+---
 fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
@@ -5,9 +6,5 @@ fixtures:
     python: https://github.com/voxpupuli/puppet-python.git
     epel: https://github.com/voxpupuli/puppet-epel.git
     apache: https://github.com/puppetlabs/puppetlabs-apache.git
-    selinux_core:
-      repo: https://github.com/puppetlabs/puppetlabs-selinux_core.git
-      puppet_version: ">= 6.0.0"
-    yumrepo_core:
-      repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
-      puppet_version: ">= 6.0.0"
+    selinux_core: https://github.com/puppetlabs/puppetlabs-selinux_core.git
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git


### PR DESCRIPTION
We only test on Puppet 6 and newer, we don't need the dependency anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
