### PR TITLE
Drop Debian 10 and FreeBSD 12

### DIFF
--- a/data/os/Debian.10.yaml
+++ b/data/os/Debian.10.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.7'

--- a/data/os/RedHat.7.yaml
+++ b/data/os/RedHat.7.yaml
@@ -1,1 +1,0 @@
-puppetboard::python_version: '3.6'

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -36,7 +35,6 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "12",
         "13",
         "14"
       ]


### PR DESCRIPTION
#### Pull Request (PR) description

* Debian 10 and FreeBSD 12 are now EOL
* Remove remaining EL7-related files
