### PR TITLE
init.pp: set `${basedir}/puppetboard` mode to `0755`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,7 @@ class puppetboard (
         ensure  => directory,
         recurse => true,
         force   => true,
+        mode   => '0755',
         purge   => true, # such cleanup is needed in case of a switch from install_from=vcsrepo to install_from=pip
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,7 +174,7 @@ class puppetboard (
         ensure  => directory,
         recurse => true,
         force   => true,
-        mode   => '0755',
+        mode    => '0755',
         purge   => true, # such cleanup is needed in case of a switch from install_from=vcsrepo to install_from=pip
       }
 


### PR DESCRIPTION
init.pp: in case of install_from pip access rights to ${basedir}/puppetboard are too restrictive

#### Pull Request (PR) description

In case I install_from pip the access rights of the directory `${basedir}/puppetboard` might be too restrictive.
In my case: user+group were root, and access rights for others were not available (as the umask was very restrictive).
So these rights need to be set explicitly, which this patch does.
