### PR TITLE
Add support for Ubuntu 24.04

### DIFF
--- a/data/os/Ubuntu.24.04.yaml
+++ b/data/os/Ubuntu.24.04.yaml
@@ -1,0 +1,2 @@
+---
+puppetboard::python_version: '3.12'

--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "22.04"
+        "22.04",
+        "24.04"
       ]
     }
   ],


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for Ubuntu 24.04 by setting the Python version, just like Ubuntu 20.04 and 22.04.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-puppetboard/issues/434
