### PR TITLE
Fix ownership of ${basedir}/puppetboard

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,8 @@ class puppetboard (
         ensure  => directory,
         recurse => true,
         force   => true,
+        owner   => $user,
+        group   => $group,
         mode    => '0755',
         purge   => true, # such cleanup is needed in case of a switch from install_from=vcsrepo to install_from=pip
       }


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Hi,
11c3dd1a77812db8489e0d930d3a08c1835194ee fixed the mode of the directory but not its ownership.
As `$basedir`'s owner is fixed, so should its `puppetboard` subdirectory.
