### PR TITLE
Fix conditional check for puppetdb_ssl_verify

### DIFF
--- a/templates/settings.py.epp
+++ b/templates/settings.py.epp
@@ -9,7 +9,7 @@ PUPPETDB_HOST = '<%= $puppetboard::puppetdb_host %>'
 <%- if $puppetboard::puppetdb_port { -%>
 PUPPETDB_PORT = <%= $puppetboard::puppetdb_port %>
 <%- } -%>
-<%- if type($puppetboard::puppetdb_ssl_verify) == String { -%>
+<%- if $puppetboard::puppetdb_ssl_verify =~ String { -%>
 PUPPETDB_SSL_VERIFY = '<%= $puppetboard::puppetdb_ssl_verify %>'
 <%- } elsif $puppetboard::puppetdb_ssl_verify { -%>
 PUPPETDB_SSL_VERIFY = True


### PR DESCRIPTION
Use =~ instead of type() for checking Puppet type in template, as the latter was not passing the check and resulted in just outputting "True"

#### Pull Request (PR) description
Update the check in the EPP template so that it correctly uses the full path to the CA certificate if specified.

#### This Pull Request (PR) fixes the following issues
Fixes #459 
